### PR TITLE
Support configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-thing-transformer",
     "packageName": "bm-thing-transformer",
     "moduleName": "bm-thing-transformer",
-    "version": "0.13.1-beta.1",
+    "version": "0.15.0-beta.1",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-thing-transformer",
     "packageName": "bm-thing-transformer",
     "moduleName": "bm-thing-transformer",
-    "version": "0.15.0-beta.1",
+    "version": "0.14.0-beta.1",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -1,3 +1,4 @@
+
 export interface TWFieldBase<T = any> {
     name: string;
     baseType: string;
@@ -174,6 +175,8 @@ export interface TWConfigurationTable {
     name: string;
     source?: string;
 }
+
+export const TWDataThings = ['Stream', 'RemoteStream', 'DataTable', 'RemoteDataTable'];
 
 export const TWBaseTypes = {
     NOTHING: "NOTHING",

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -1,3 +1,11 @@
+export interface TWInfoTable {
+    dataShape: {
+        fieldDefinitions: Record<string, TWFieldBase>;
+    };
+
+    rows: Record<string, unknown>[];
+}
+
 
 export interface TWFieldBase<T = any> {
     name: string;


### PR DESCRIPTION
Adds support for extracting the generic argument from data thing superclasses and using it to create an appropriate configuration table in the exported XML.

Adds preliminary support for the `@config` decorator. Currently this isn't properly checked,