### PR TITLE
fix: Generate correct instance permissions for TT and TS

### DIFF
--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -809,12 +809,16 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
     /**
      * Returns a list of permissions for the given node.
-     * @param node          The node whose permissions should be retrieved.
-     * @param resource      The resource to which the permissions should refer. If specified and any decorator
-     *                      refers to a different resource, this method will throw.
-     * @returns             A list of permissions
+     * @param node                  The node whose permissions should be retrieved.
+     * @param resource              The resource to which the permissions should refer. If specified and any decorator
+     *                              refers to a different resource, this method will throw.
+     * @param forceRuntimeInstance  Force setting the permissions on the runtime instance, instead on the entity level.
+     *                              Useful for permissions on properties, services and event specified directly on the method declarations
+     *                              or property declarations where both `@allow`/`@deny` and `@allowInstance`/`@denyInstance` can be used
+     *                              and result in the same runtime instance declaration.`
+     * @returns                     A list of permissions
      */
-    permissionsOfNode(node: ts.Node, resource: string = '*'): TWExtractedPermissionLists {
+    permissionsOfNode(node: ts.Node, resource: string = '*', forceRuntimeInstance = false): TWExtractedPermissionLists {
         // Filter out the list of decorators to exclude any non-permission decorators
         const decorators = node.decorators?.filter(d => d.expression.kind == ts.SyntaxKind.CallExpression && PermissionDecorators.includes((d.expression as ts.CallExpression).expression.getText()));
         const result: TWExtractedPermissionLists = {};
@@ -849,7 +853,11 @@ Failed parsing at: \n${node.getText()}\n\n`);
                     permissionKind = 'runtimeInstance';
                     break;
                 default:
-                    this.throwErrorForNode(node, `Unkown permission decorator '${text}' specified.`)
+                    this.throwErrorForNode(node, `Unknown permission decorator '${text}' specified.`)
+            }
+
+            if (forceRuntimeInstance) {
+                permissionKind = 'runtimeInstance';
             }
 
             // Determine if this decorator applies to a specific property or to the entire node
@@ -1557,7 +1565,17 @@ Failed parsing at: \n${node.getText()}\n\n`);
         }
 
         // Extract the permissions to be applied per user
-        this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions].concat(this.permissionsOfNode(node, node.name.text)), node);
+        this.runtimePermissions = this.mergePermissionListsForNode(
+          [this.runtimePermissions].concat(
+            this.permissionsOfNode(
+              node,
+              node.name.text,
+              this.entityKind == TWEntityKind.ThingShape ||
+                this.entityKind == TWEntityKind.ThingTemplate
+            )
+          ),
+          node
+        );
     }
 
     /**
@@ -1948,8 +1966,16 @@ Failed parsing at: \n${node.getText()}\n\n`);
             }
         }
 
-        this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions].concat(this.permissionsOfNode(node, node.name.text)), node);
-
+        this.runtimePermissions = this.mergePermissionListsForNode(
+            [this.runtimePermissions].concat(
+                this.permissionsOfNode(
+                    node,
+                    node.name.text,
+                    this.entityKind == TWEntityKind.ThingShape || this.entityKind == TWEntityKind.ThingTemplate,
+                ),
+            ),
+            node,
+        );
         this.properties.push(property);
     }
 
@@ -1991,8 +2017,16 @@ Failed parsing at: \n${node.getText()}\n\n`);
             event.remoteBinding.sourceName = (arg as ts.StringLiteral).text;
         }
 
-        this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions].concat(this.permissionsOfNode(node, node.name.text)), node);
-
+        this.runtimePermissions = this.mergePermissionListsForNode(
+            [this.runtimePermissions].concat(
+                this.permissionsOfNode(
+                    node,
+                    node.name.text,
+                    this.entityKind == TWEntityKind.ThingShape || this.entityKind == TWEntityKind.ThingTemplate,
+                ),
+            ),
+            node,
+        );
         this.events.push(event);
     }
 
@@ -2344,8 +2378,17 @@ Failed parsing at: \n${node.getText()}\n\n`);
             this.deploymentEndpoints.push(`Things/${this.exportedName}/Services/${service.name}`);
         }
 
-        this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions].concat(this.permissionsOfNode(node, service.name)), node);
-
+        this.runtimePermissions = this.mergePermissionListsForNode(
+            [this.runtimePermissions].concat(
+                this.permissionsOfNode(
+                    node,
+                    service.name,
+                    this.entityKind == TWEntityKind.ThingShape || this.entityKind == TWEntityKind.ThingTemplate,
+                ),
+            ),
+            node,
+        );
+        
         this.services.push(service);
         return node;
     }


### PR DESCRIPTION
All permission decorators applied on class members of ThingShapes and ThingTemplates should lead to generation InstanceRunTimePermissions, not RunTimePermissions.

My code approach is a bit rough, but i had no other idea of how to pass along the context into the `permissionsOfNode` method