### PR TITLE
Fix basetype errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+Added support for using inferred types in property declarations and data shape field declarations. ([stefan-lacatus](https://github.com/stefan-lacatus))
+
+Resolved an issue that cause base type errors to report the invalid base types as `undefined` rather than the actual types.
+
 # 0.18.0-beta.1
 
 Removed `gulp` as a dev dependency and the build script using it. Use `npm run build` to build this release, which just executes `tsc` directly.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations
 
 #  License
 

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -1585,13 +1585,13 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         const ordinal = this.numericArgumentOfDecoratorNamed('ordinal', node);
         if (ordinal) {
-            if (!parseInt(ordinal)) this.throwErrorForNode(node, `Non numeric value specified in ordinal decorator for property ${property.name}: ${property.baseType}`);
+            if (!parseInt(ordinal)) this.throwErrorForNode(node, `Non numeric value specified in ordinal decorator for property ${property.name}: ${baseType}`);
             property.ordinal = parseInt(ordinal);
         }
 
         // Ensure that the base type is one of the Thingworx Base Types
         if (!(baseType in TWBaseTypes)) {
-            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${property.baseType}`);
+            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${baseType}`);
         }
         property.baseType = TWBaseTypes[baseType];
 
@@ -1690,7 +1690,7 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         // Ensure that the base type is one of the Thingworx Base Types
         if (!(baseType in TWBaseTypes)) {
-            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${property.baseType}`);
+            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${baseType}`);
         }
         property.baseType = TWBaseTypes[baseType];
 


### PR DESCRIPTION
Fixes error messages for unknown base types that were previously reporting the unknown base types as `undefined` rather than the actual type.