### PR TITLE
Force template and shape permissions to be runtime instance

### DIFF
--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -825,9 +825,9 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         // When the permission decorators are applied to a shape or template's fields it is always
         // interpreted as a runtime instance permission
-        let isTemplateFieldPermission = false;
+        let isInstanceMemberPermission = false;
         if (!ts.isClassDeclaration(node) && [TWEntityKind.ThingShape, TWEntityKind.ThingTemplate].includes(this.entityKind)) {
-            isTemplateFieldPermission = true;
+            isInstanceMemberPermission = true;
         }
 
         for (const decorator of decorators) {
@@ -860,7 +860,7 @@ Failed parsing at: \n${node.getText()}\n\n`);
             }
 
             // For template and thing shape fields, the permission kind is always runtime instance
-            if (isTemplateFieldPermission) {
+            if (isInstanceMemberPermission) {
                 permissionKind = 'runtimeInstance';
             }
 

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -823,6 +823,13 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         const permissionLists: TWExtractedPermissionLists[] = [];
 
+        // When the permission decorators are applied to a shape or template's fields it is always
+        // interpreted as a runtime instance permission
+        let isTemplateFieldPermission = false;
+        if (!ts.isClassDeclaration(node) && [TWEntityKind.ThingShape, TWEntityKind.ThingTemplate].includes(this.entityKind)) {
+            isTemplateFieldPermission = true;
+        }
+
         for (const decorator of decorators) {
             const text = (decorator.expression as ts.CallExpression).expression.getText();
 
@@ -850,6 +857,11 @@ Failed parsing at: \n${node.getText()}\n\n`);
                     break;
                 default:
                     this.throwErrorForNode(node, `Unkown permission decorator '${text}' specified.`)
+            }
+
+            // For template and thing shape fields, the permission kind is always runtime instance
+            if (isTemplateFieldPermission) {
+                permissionKind = 'runtimeInstance';
             }
 
             // Determine if this decorator applies to a specific property or to the entire node


### PR DESCRIPTION
Fixes permissions declared on template or shape fields that were meant to be runtime instance permissions, but were instead emitted as runtime permissions.