### PR TITLE
V 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# TBD
+# 0.19.0-beta.1
 
 Added support for using inferred types in property declarations and data shape field declarations. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 Resolved an issue that cause base type errors to report the invalid base types as `undefined` rather than the actual types.
+
+Resolved an issue that caused permission decorators applied to templates to be incorrectly emitted as runtime permissions instead of instance runtime permissions. ([stefan-lacatus](https://github.com/stefan-lacatus))
+
+Resolved an issue that caused multiproject builds to fail on windows systems.
 
 # 0.18.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# TBD
+
+Added support for using inferred types in property declarations and data shape field declarations. ([stefan-lacatus](https://github.com/stefan-lacatus))
+
+Resolved an issue that cause base type errors to report the invalid base types as `undefined` rather than the actual types.
+
 # 0.18.0-beta.1
 
 Removed `gulp` as a dev dependency and the build script using it. Use `npm run build` to build this release, which just executes `tsc` directly.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations
 
 #  License
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
- - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, instance permissions bug fixes
 
 #  License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "0.18.0-beta.1",
+    "version": "0.19.0-beta.1",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -824,6 +824,13 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         const permissionLists: TWExtractedPermissionLists[] = [];
 
+        // When the permission decorators are applied to a shape or template's fields it is always
+        // interpreted as a runtime instance permission
+        let isInstanceMemberPermission = false;
+        if (!ts.isClassDeclaration(node) && [TWEntityKind.ThingShape, TWEntityKind.ThingTemplate].includes(this.entityKind)) {
+            isInstanceMemberPermission = true;
+        }
+
         for (const decorator of decorators) {
             const text = (decorator.expression as ts.CallExpression).expression.getText();
 
@@ -851,6 +858,11 @@ Failed parsing at: \n${node.getText()}\n\n`);
                     break;
                 default:
                     this.throwErrorForNode(node, `Unkown permission decorator '${text}' specified.`)
+            }
+
+            // For template and thing shape fields, the permission kind is always runtime instance
+            if (isInstanceMemberPermission) {
+                permissionKind = 'runtimeInstance';
             }
 
             // Determine if this decorator applies to a specific property or to the entire node

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -1585,13 +1585,13 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         const ordinal = this.numericArgumentOfDecoratorNamed('ordinal', node);
         if (ordinal) {
-            if (!parseInt(ordinal)) this.throwErrorForNode(node, `Non numeric value specified in ordinal decorator for property ${property.name}: ${property.baseType}`);
+            if (!parseInt(ordinal)) this.throwErrorForNode(node, `Non numeric value specified in ordinal decorator for property ${property.name}: ${baseType}`);
             property.ordinal = parseInt(ordinal);
         }
 
         // Ensure that the base type is one of the Thingworx Base Types
         if (!(baseType in TWBaseTypes)) {
-            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${property.baseType}`);
+            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${baseType}`);
         }
         property.baseType = TWBaseTypes[baseType];
 
@@ -1690,7 +1690,7 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         // Ensure that the base type is one of the Thingworx Base Types
         if (!(baseType in TWBaseTypes)) {
-            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${property.baseType}`);
+            this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${baseType}`);
         }
         property.baseType = TWBaseTypes[baseType];
 


### PR DESCRIPTION
Added support for using inferred types in property declarations and data shape field declarations.

Resolved an issue that cause base type errors to report the invalid base types as `undefined` rather than the actual types.

Resolved an issue that caused permission decorators applied to templates to be incorrectly emitted as runtime permissions instead of instance runtime permissions.

Resolved an issue that caused multiproject builds to fail on windows systems.