### PR TITLE
V 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.22.0-beta.1
+
+Adds support for declaring and inlining global functions.
+
+The transformer will no longer replace instances of `this` with `me`. Instead it will always use anonymous functions invoked with apply to set the appropriate context.
+
+The transformer will now only declare the method helpers that are referenced in each service, instead of always including them.
+
 # 0.21.1-beta.1
 
 Improved the infotable type ([stefan-lacatus](https://github.com/stefan-lacatus)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The transformer will no longer replace instances of `this` with `me`. Instead it
 
 The transformer will now only declare the method helpers that are referenced in each service, instead of always including them.
 
+Added support for using the `@exported` decorator to generate an API declarations file that can be consumed by a separate frontend or node project. ([stefan-lacatus](https://github.com/stefan-lacatus))
+
 # 0.21.1-beta.1
 
 Improved the infotable type ([stefan-lacatus](https://github.com/stefan-lacatus)):

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
- - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, instance permissions bug fixes
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation
 
 #  License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "bm-thing-transformer",
-    "version": "0.21.1-beta.1",
+    "version": "0.22.0-beta.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-transformer",
-            "version": "0.21.1-beta.1",
+            "version": "0.22.0-beta.1",
             "license": "MIT",
             "dependencies": {
-                "typescript": "4.5.5",
+                "typescript": "4.6.3",
                 "xml2js": "^0.4.23"
             },
             "devDependencies": {
@@ -35,9 +35,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "node_modules/typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -86,9 +86,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
         },
         "xml2js": {
             "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "0.21.1-beta.1",
+    "version": "0.22.0-beta.1",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",
@@ -27,7 +27,7 @@
         "@types/node": "^8.10.11"
     },
     "dependencies": {
-        "typescript": "4.5.5",
+        "typescript": "4.6.3",
         "xml2js": "^0.4.23"
     }
 }

--- a/src/configuration/TWConfig.ts
+++ b/src/configuration/TWConfig.ts
@@ -5,19 +5,22 @@ export interface MethodHelpers {
      * Generates a `METHOD_NAME` constant with the name of the service or subscription 
      */
     methodName?: boolean;
+
     /**
-    * Generates a `CLASS_NAME` constant with the name of the class this function is declared in
-    */
+     * Generates a `CLASS_NAME` constant with the name of the class this function is declared in
+     */
     className?: boolean;
-   /**
-    * Generates a `FILE_PATH` constant with the relative path of the file
-    */
+
+    /**
+     * Generates a `FILE_PATH` constant with the relative path of the file
+     */
     filePath?: boolean;
-   /**
+
+    /**
      * Generates a `LOG_PREFIX` constant with the name of the service
      * Example: `${me.name}::${METHOD_NAME}::
-    */
-   logPrefix?: string;
+     */
+    logPrefix?: string;
 }
 
 /**
@@ -67,7 +70,13 @@ export interface TWConfig {
     /**
      * Configuration for the generation of method helpers that can be used used within services and subscriptions 
      */
-     methodHelpers?: MethodHelpers;
+    methodHelpers?: MethodHelpers;
+
+    /**
+     * When enabled, global function declarations are permitted and any service that references a global function will
+     * gain a copy of it.
+     */
+    globalFunctions?: boolean;
 
     /**
      * The minimum thingworx version on which the project may be installed.
@@ -105,7 +114,9 @@ export interface TWConfig {
     debug?: boolean;
 
     /**
-     * An object holding transformer instances.
+     * An object holding transformer instances and global metadata.
      */
-    store: {[key: string]: TWThingTransformer};
+    store: {
+        [key: string]: TWThingTransformer;
+    };
 }

--- a/src/transformer/APIDeclarationGenerator.ts
+++ b/src/transformer/APIDeclarationGenerator.ts
@@ -1,0 +1,119 @@
+import {TWServiceDefinition, TWPropertyDefinition, TWServiceParameter, TWDataShapeField } from './TWCoreTypes';
+
+ /**
+  * A regex that is used to test if a string has any non-alphanumeric character.
+  */
+ export const NonAlphanumericRegex = /[^a-zA-Z\d_]/;
+ 
+ /**
+  * A regex that is used to replace non alphanumeric characters in strings.
+  */
+ export const NonAlphanumericRegexGlobal = /[^a-zA-Z\d_]/g;
+ 
+/**
+ * A class that contains various static methods for parsing entity metadata
+ * objects into typescript class declarations.
+ */
+ export class APIGenerator {
+
+    /**
+     * Returns a string that represents the typescript type that should be used to represent
+     * the given property definition's base type.
+     * @param definition        The property definition.
+     * @returns                 A typescript type string.
+     */
+    static baseTypeOfPropertyDefinition(definition: TWServiceParameter, serviceParameter = false): string {
+        let baseType = definition.baseType;
+
+        if (baseType == 'JSON') return 'TWJSON';
+
+        if (baseType == 'INFOTABLE' && definition.aspects.dataShape) {
+            if (NonAlphanumericRegex.test(definition.aspects.dataShape)) {
+                return `INFOTABLE<${JSON.stringify(definition.aspects.dataShape)}>`;
+            }
+            else {
+                return `INFOTABLE<${definition.aspects.dataShape}>`;
+            }
+        } else {
+
+            if (baseType == 'THINGNAME') {
+                baseType = 'STRING';
+            }
+            return serviceParameter ? `[{result: ${baseType}}]` : baseType;
+        }
+
+    }
+
+    /**
+     * Returns a string that represents the literal type of the given service's argument object.
+     * @param service       The service definition.
+     * @returns             A typescript type string.
+     */
+    static argumentTypesOfService(service: TWServiceDefinition): string {
+        let args: string[] = [];
+
+        for (const argument of service.parameterDefinitions) {
+            args.push(`${argument.name}${argument.aspects.isRequired || argument.aspects.defaultValue ? '' : '?'}: ${this.baseTypeOfPropertyDefinition(argument)}`);
+        }
+
+        return args.length > 0 ? `args: {${args.join(',')}}` : 'args?: Record<string, never>';
+    }
+
+    /**
+     * Returns a string that represents the portion of JSDoc that documents the arguments of the given service definition.
+     * @param service       The service definition.
+     * @returns             A string representing a portion of a JSDoc comment.
+     */
+    static argumentDocumentationsOfService(service: TWServiceDefinition): string {
+        let docs: string[] = [];
+
+        for (const argument of service.parameterDefinitions) {
+            docs.push(`@param ${argument.name} ${argument.description}`);
+        }
+
+        return docs.join('\n\t * ');
+    }
+
+    /**
+     * Returns a string that represents a typescript declaration of a given property definition.
+     * @param property          The property definition.
+     * @returns                 A string representing a property declaration.
+     */
+    static declarationOfProperty(property: TWPropertyDefinition | TWDataShapeField): string {
+        // Use string literal for names with special characters
+        let name = property.name;
+        if (NonAlphanumericRegex.test(name)) {
+            name = JSON.stringify(name);
+        }
+
+        return `
+    /**
+     * ${property.description}
+     */
+    ${name}: ${this.baseTypeOfPropertyDefinition(property)};
+    `;
+    }
+
+    /**
+     * Returns a string that represents a typescript declaration of a given service definition.
+     * @param service           The service definition.
+     * @returns                 A string representing a service declaration.
+     */
+    static declarationOfService(service: TWServiceDefinition): string {
+        // Use string literals for names with special characters
+        let name = service.name;
+        if (NonAlphanumericRegex.test(name)) {
+            name = JSON.stringify(name);
+        }
+
+        return `
+    /**
+     * ${service.description}
+     * ${this.argumentDocumentationsOfService(service)}
+     * @return ${service.resultType.description}
+     */
+    ${name}(${this.argumentTypesOfService(service)}): ${service.aspects.isAsync ? 'ServiceResult<NOTHING>' : 'ServiceResult<' + this.baseTypeOfPropertyDefinition(service.resultType, true) + '>'};
+`;
+    }
+
+}

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -1,3 +1,6 @@
+import type { Node, SourceFile } from 'typescript';
+import type { EmitHelper } from 'typescript';
+
 export interface TWInfoTable {
     dataShape: {
         fieldDefinitions: Record<string, TWFieldBase>;
@@ -127,6 +130,16 @@ export interface TWServiceDefinition {
     isOverriden?: boolean;
 
     /**
+     * An array of global functions referenced in the body of this service.
+     */
+    '@globalFunctions': Set<string>;
+
+    /**
+     * An array of method helpers referenced in the body of this service.
+     */
+    '@methodHelpers': Set<string>;
+
+    /**
      * An optional object containing additional information about the service if it is a sql service.
      */
     SQLInfo?: {
@@ -189,6 +202,16 @@ export interface TWSubscriptionDefinition {
     sourceType: TWSubscriptionSourceKind;
     sourceProperty: string;
     code: string;
+
+    /**
+     * An array of global functions referenced in the body of this subscription.
+     */
+    '@globalFunctions': Set<string>;
+
+    /**
+     * An array of method helpers referenced in the body of this subscription.
+     */
+    '@methodHelpers': Set<string>;
 }
 
 export const enum TWSubscriptionSourceKind {
@@ -451,4 +474,60 @@ export interface TWOrganizationalUnit {
     description?: string;
     name: string;
     members: TWMemberBase[];
+}
+
+/**
+ * The interface for an object that identifies a global function.
+ */
+export interface GlobalFunction {
+
+    /**
+     * The name of the function.
+     */
+    name: string;
+
+    /**
+     * The file where the function is defined.
+     */
+    filename: string;
+
+    /**
+     * An array of global functions that this function invokes.
+     */
+    dependencies: Set<string>;
+
+    /**
+     * An array of method helpers that this function uses.
+     */
+    methodHelperDependencies: Set<string>;
+
+    /**
+     * An array of emit helper that this function uses.
+     */
+    emitHelperDependencies?: EmitHelper[];
+
+    /**
+     * The transformed node of the function.
+     */
+    node: Node;
+
+    /**
+     * The compiled code of the function.
+     */
+    compiledCode?: string;
+
+    /**
+     * The source file where this function is defined.
+     */
+    sourceFile: SourceFile;
+}
+
+/**
+ * The interface for an object that describes a reference to a global function.
+ */
+export interface GlobalFunctionReference {
+    /**
+     * The name of the function.
+     */
+    name: string;
 }

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -2,7 +2,8 @@ import * as ts from 'typescript';
 import { MethodHelpers, TWConfig } from '../configuration/TWConfig';
 import { TWEntityKind, TWPropertyDefinition, TWServiceDefinition, TWEventDefinition, TWSubscriptionDefinition, TWBaseTypes, TWPropertyDataChangeKind, TWFieldBase, TWPropertyRemoteBinding, TWPropertyRemoteFoldKind, TWPropertyRemotePushKind, TWPropertyRemoteStartKind, TWPropertyBinding, TWSubscriptionSourceKind, TWServiceParameter, TWDataShapeField, TWConfigurationTable, TWRuntimePermissionsList, TWVisibility, TWExtractedPermissionLists, TWRuntimePermissionDeclaration, TWPrincipal, TWPermission, TWUser, TWUserGroup, TWPrincipalBase, TWOrganizationalUnit, TWConnection, TWDataThings, TWInfoTable } from './TWCoreTypes';
 import { Breakpoint } from './DebugTypes';
-import {Builder} from 'xml2js';
+import { APIGenerator } from './APIDeclarationGenerator';
+import { Builder } from 'xml2js';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as path from 'path';
@@ -144,6 +145,13 @@ export class TWThingTransformer {
      * For things, this represents the published flag if it has been set.
      */
     published: boolean = false;
+
+    /**
+     * **EXPERIMENTAL!!!**
+     *
+     * For Things and DataShapes, this triggers the generation of APIs
+     */
+    exported: boolean = false;
 
     /**
      * Controls whether the class represents an editable extension object.
@@ -1222,6 +1230,12 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
             if (this.published && this.entityKind != TWEntityKind.Thing) {
                 this.throwErrorForNode(node, `Only Things may be published.`);
+            }
+
+            this.exported = this.hasDecoratorNamed('exported', classNode);
+
+            if (this.exported && !(this.entityKind == TWEntityKind.Thing || this.entityKind == TWEntityKind.DataShape)) {
+                this.throwErrorForNode(node, `Only Things or DataShapes may be exported.`);
             }
 
             this.editable = !!classNode.decorators && classNode.decorators.some(decorator => decorator.expression.kind == ts.SyntaxKind.Identifier && decorator.expression.getText() == 'editable');
@@ -3527,6 +3541,34 @@ finally {
         }
 
         return implementation;
+    }
+
+    /**
+     * Exposed entities declarations
+     * @returns API representation of the exposed entities
+     */
+    toAPIDeclaration(): string {
+        if (this.exported) {
+            if (this.entityKind == TWEntityKind.DataShape) {
+                return `export interface ${this.exportedName} {
+                    ${this.fields.map(f => APIGenerator.declarationOfProperty(f)).join('\n')}
+                }`;
+            }
+            else if (this.entityKind == TWEntityKind.Thing) {
+                return `export class ${this.exportedName} {
+                    ${this.services.map(f=> APIGenerator.declarationOfService(f)).join('\n')}
+                }
+                export interface Things {
+                    "${this.exportedName}": ${this.exportedName};
+                }`;
+            }
+            else {
+                throw new Error('Only Things and DataShapes can be exposed in API');
+            }
+        }
+        else {
+            return "";
+        }
     }
 
     /**

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -2484,6 +2484,10 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 if (!type) this.throwErrorForNode(node, `Parameter ${parameter.name} is untyped.`);
 
                 const typeNode = type.type as ts.TypeReferenceNode;
+                
+                if (!typeNode) {
+                    this.throwErrorForNode(node, `No base type specified for parameter ${parameter.name}.`);
+                }
 
                 parameter.aspects.isRequired = !type.questionToken;
                 const baseType = TypeScriptPrimitiveTypes.includes(typeNode.kind) ? typeNode.getText() : typeNode.typeName.getText();

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -3583,6 +3583,15 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
         if (this.methodHelpers) {
             // Prefix a new line at the start of the method
+            const logPrefix = this.methodHelpers.logPrefix;
+
+            // Get the helpers used by log prefix
+            for (const helper of MethodHelperIdentifiers) {
+                if (logPrefix?.includes(helper)) {
+                    method['@methodHelpers'].add(helper);
+                }
+            }
+
             result = '\n' + result;
             if (this.methodHelpers.methodName && method['@methodHelpers'].has('METHOD_NAME')) {
                 result = `const METHOD_NAME = "${name}";\n` + result;

--- a/static/types/Decorators.d.ts
+++ b/static/types/Decorators.d.ts
@@ -384,8 +384,15 @@ declare function allowInstance(...args: (UserEntity | GroupEntity | Permission)[
  */
  declare function visible(...args: (OrganizationEntity)[]): <T extends new (...args) => unknown>(target: T) => void;
 
- /**
-  * A decorator that can be used to make an entity visible for a set of given organizations.
-  * @param args      A comma separated list of organizations.
-  */
-  declare function visibleInstance(...args: (OrganizationEntity)[]): <T extends new (...args) => unknown>(target: T) => void;
+/**
+ * A decorator that can be used to make an entity visible for a set of given organizations.
+ * @param args      A comma separated list of organizations.
+ */
+declare function visibleInstance(...args: (OrganizationEntity)[]): <T extends new (...args) => unknown>(target: T) => void;
+
+/**
+ * **EXPERIMENTAL**
+ * 
+ * Causes the given entity to be exposed and used in the API type generation
+ */
+declare function exported<K extends new (...args) => GenericThing | DataShapeBase>(target: K);


### PR DESCRIPTION
Adds support for declaring and inlining global functions.

The transformer will no longer replace instances of `this` with `me`. Instead it will always use anonymous functions invoked with apply to set the appropriate context.

The transformer will now only declare the method helpers that are referenced in each service, instead of always including them.

Added support for using the `@exported` decorator to generate an API declarations file that can be consumed by a separate frontend or node project. ([stefan-lacatus](https://github.com/stefan-lacatus))