### PR TITLE
Fix before transformer when used with ts.transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -699,7 +699,7 @@ Failed parsing at: \n${node.getText()}\n\n`);
             }
         } else {
             // Otherwise it may just be a const enum
-            return ((this.context as any).getEmitResolver() as ts.TypeChecker).getConstantValue(expression as ts.PropertyAccessExpression);
+            return this.program.getTypeChecker().getConstantValue(expression as ts.PropertyAccessExpression);
         }
 
         return undefined;


### PR DESCRIPTION
Resolves an issue where using the transformer with `ts.transform` instead of `program.emit` would lead to an error when attempting to resolve constant values.