### PR TITLE
Fix missing helper dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Resolves an issue where using the transformer with `ts.transform` would throw an
 
 The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))
 
+Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.


### PR DESCRIPTION
Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features. This happens because the `__read` helper depends on `__values` through its customized code, but the typescript compiler is not aware of this, so it doesn't include it unless some other piece of code requires it.