### PR TITLE
Data shape parent inheritance

### DIFF
--- a/static/types/TWBaseTypes.d.ts
+++ b/static/types/TWBaseTypes.d.ts
@@ -748,7 +748,7 @@ declare function DataShapeBase<
     T13 extends Constructor<DataShapeBase> | {} = {},
     > (
         mix1: T1,
-        mix2: T2,
+        mix2?: T2,
         mix3?: T3,
         mix4?: T4,
         mix5?: T5,
@@ -810,7 +810,7 @@ declare function DataShapeBaseReference<
     T13 extends keyof DataShapes | {} = {},
     > (
         mix1: T1,
-        mix2: T2,
+        mix2?: T2,
         mix3?: T3,
         mix4?: T4,
         mix5?: T5,


### PR DESCRIPTION
Fixes an issue where data shape inheritance would sometimes be incomplete if a data shape inherited from a data shape that also had a base data shape but the files were not processed in the right order.

Also fixes a typing issue that required the `DataShapeBase` mixin to have at least two arguments.