### PR TITLE
Global functions and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The transformer will no longer emit members with the `declare` modifier.  [stefa
 
 Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.
 
+Resolves an issue where having global functions enabled would also cause the transformer to inline functions declared in global code.
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -3326,6 +3326,17 @@ Failed parsing at: \n${node.getText()}\n\n`);
                     const filename = path.normalize(sourceFile.fileName);
                     const name = functionDeclaration.name?.text;
 
+                    // Validate that the source file is not global code
+                    const firstStatement = sourceFile.statements[0];
+                    if (ts.isExpressionStatement(firstStatement) && ts.isStringLiteralLike(firstStatement.expression)) {
+                        const text = firstStatement.expression.text;
+                        const components = text.split(' ');
+                        if (components[0] == 'use' && components[1] != 'strict') {
+                            // If the function is part of global code, it does not need inlining
+                            break;
+                        }
+                    }
+
                     // Validate that the source is part of the repo; in multi project mode
                     // this can also be a global function declared in a different project
                     if (!filename.startsWith(this.repoPath)) break;


### PR DESCRIPTION
Resolves an issue where having global functions enabled would also cause the transformer to inline functions declared in global code.