### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The transformer will no longer emit members with the `declare` modifier.  [stefa
 
 Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.
 
+Resolves an issue where having global functions enabled would also cause the transformer to inline functions declared in global code.
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.0
+
+Adds support for data shape inheritance. [stefan-lacatus](https://github.com/stefan-lacatus))
+
 Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
 
 # 1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Resolves an issue where using the transformer with `ts.transform` would throw an
 
 The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))
 
+Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Adds support for data shape inheritance. [stefan-lacatus](https://github.com/ste
 
 Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
 
+The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
- - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation, data shape inheritance, `declare` modifier on members
 
 #  License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ const emitResult = program.emit(undefined, () => {}, undefined, undefined, {
         TWThingTransformerFactory(program, path, true, false, twConfig)
     ]
 });
+
+// Fire post transform actions, which enable features like data shape inheritance
+for (const key in twConfig.store) {
+    // Exclude non-transformer entries
+    if (key.startsWith('@')) continue;
+
+    twConfig.store[key].firePostTransformActions();
+}
 ```
 
 After the emit finishes, the transformers will properties to the `store` object of your twconfig object. This is an object whose keys are the names of the generated entities and their values are each an instance of the transformer. Beyond those related to the actual transformation, the transformer has the following public methods that can be invoked after the program's emit method returns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-transformer",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "typescript": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -27,6 +27,11 @@ export interface TWFieldAspects<T> {
 
 export interface TWDataShapeField<T = any> extends TWFieldBase<T> {
     aspects: TWDataShapeFieldAspects<T>;
+
+    /**
+     * Set to `true` if the field was declared with the `override` keyword.
+     */
+    '@isOverriden'?: boolean;
 }
 
 export interface TWDataShapeFieldAspects<T> extends TWFieldAspects<T> {

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -699,7 +699,7 @@ Failed parsing at: \n${node.getText()}\n\n`);
             }
         } else {
             // Otherwise it may just be a const enum
-            return ((this.context as any).getEmitResolver() as ts.TypeChecker).getConstantValue(expression as ts.PropertyAccessExpression);
+            return this.program.getTypeChecker().getConstantValue(expression as ts.PropertyAccessExpression);
         }
 
         return undefined;

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -1665,6 +1665,11 @@ Failed parsing at: \n${node.getText()}\n\n`);
         if (node.kind == ts.SyntaxKind.Constructor) {
             this.throwErrorForNode(node, `Constructors are not supported in Thingworx classes.`);
         }
+        
+        // Class members with the declare modifier should be ignored
+        if (node.modifiers?.some(m => m.kind == ts.SyntaxKind.DeclareKeyword)) {
+            return;
+        }
 
         if (node.kind == ts.SyntaxKind.PropertyDeclaration) {
             const propertyDeclarationNode = node as ts.PropertyDeclaration;

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -701,7 +701,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 // If this is an environment variable, inline it
                 return process.env[value];
             }
-        } else {
+        }
+        else {
             // Otherwise it may just be a const enum
             return this.program.getTypeChecker().getConstantValue(expression as ts.PropertyAccessExpression);
         }
@@ -1879,7 +1880,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
                 this.userGroups[group.name] = group;
             }
-        } else {
+        }
+        else {
             // Properties without an initializer default to being treated as users with no extensions
             const user = principal as TWUser;
             user.extensions = {};
@@ -2282,7 +2284,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
             }
             const typeNode = node.type as ts.TypeReferenceNode;
             return TypeScriptPrimitiveTypes.includes(typeNode.kind) ? typeNode.getText() : typeNode.typeName.getText();
-        } else {
+        }
+        else {
             // If a type has not been specified, try to infer it from the context
             const typeChecker = this.program.getTypeChecker();
             const inferredType = typeChecker.getTypeAtLocation(node);
@@ -2537,7 +2540,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 else {
                     this.throwErrorForNode(node, 'The type of the service parameter list cannot be resolved.');
                 }
-            } else {
+            }
+            else {
                type = argList.type as ts.TypeLiteralNode;
             }
 
@@ -4488,17 +4492,19 @@ finally {
             const transformer = this.store[shape] as TWThingTransformer;
             if (transformer) {
                 transformer.fields.forEach(f => {
-                    // If the property is already declared on the child, than that definition overrides the one on the parent
+                    // If the property is already declared on the child, then that definition overrides the one on the parent
                     if (!fieldNames[f.name]) {
                         fieldNames[f.name] = f;
-                    } else {
+                    }
+                    else {
                         messages.push({
                             message: `DataShape "${this.className}" contains field "${f.name}" that is also declared on the parent "${shape}". Declaration on the ${this.exportedName} is going to be used.`,
                             kind: DiagnosticMessageKind.Warning
                         });
                     }
                 })
-            } else {
+            }
+            else {
                 messages.push({
                     message: `DataShapes can only extend other dataShapes declared in the project, and not external ones. DataShape "${this.className}" extends "${shape}".`,
                     kind: DiagnosticMessageKind.Error

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -1960,6 +1960,12 @@ Failed parsing at: \n${node.getText()}\n\n`);
             property.ordinal = parseInt(ordinal);
         }
 
+        // If the field was declared with the override keyword, store this
+        // so that a warning is not generated for it
+        if (node.modifiers?.some(m => m.kind == ts.SyntaxKind.OverrideKeyword)) {
+            property['@isOverriden'] = true;
+        }
+
         // Ensure that the base type is one of the Thingworx Base Types
         if (!(baseType in TWBaseTypes)) {
             this.throwErrorForNode(node, `Unknown baseType for property ${property.name}: ${baseType}`);
@@ -4536,6 +4542,9 @@ finally {
                         fieldNames[f.name] = f;
                     }
                     else {
+                        // Only warn if the field is not explicitly overriden.
+                        if (fieldNames[f.name]['@isOverriden']) return;
+
                         messages.push({
                             message: `DataShape "${this.className}" contains field "${f.name}" that is also declared on the parent "${shape}". Declaration on the ${this.exportedName} is going to be used.`,
                             kind: DiagnosticMessageKind.Warning
@@ -5533,7 +5542,7 @@ finally {
             ordinal++;
             
             for (const key in field) {
-                if (key == 'aspects') continue;
+                if (key == 'aspects' || key.startsWith('@')) continue;
 
                 fieldDefinition.$[key] = field[key]
             }

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -3326,6 +3326,17 @@ Failed parsing at: \n${node.getText()}\n\n`);
                     const filename = path.normalize(sourceFile.fileName);
                     const name = functionDeclaration.name?.text;
 
+                    // Validate that the source file is not global code
+                    const firstStatement = sourceFile.statements[0];
+                    if (ts.isExpressionStatement(firstStatement) && ts.isStringLiteralLike(firstStatement.expression)) {
+                        const text = firstStatement.expression.text;
+                        const components = text.split(' ');
+                        if (components[0] == 'use' && components[1] != 'strict') {
+                            // If the function is part of global code, it does not need inlining
+                            break;
+                        }
+                    }
+
                     // Validate that the source is part of the repo; in multi project mode
                     // this can also be a global function declared in a different project
                     if (!filename.startsWith(this.repoPath)) break;

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -704,7 +704,41 @@ Failed parsing at: \n${node.getText()}\n\n`);
         }
         else {
             // Otherwise it may just be a const enum
-            return this.program.getTypeChecker().getConstantValue(expression as ts.PropertyAccessExpression);
+            const emitResolver: ts.TypeChecker = (this.context as any).getEmitResolver();
+
+            if (emitResolver) {
+                // The emit resolver is able to get the constant value directly
+                return emitResolver.getConstantValue(propertyAccess);
+            }
+            else {
+                // If the emit resolver isn't available (e.g. due to using ts.transform)
+                // Use the type checker to determine if the source object is an enum
+                // and find the initializer for its field
+
+                // NOTE: the type checker also has a getConstantValue method, but this
+                // does not appear to work when directly called against an enum member access
+                // expression
+                
+                const typeChecker = this.program.getTypeChecker();
+                const symbol = typeChecker.getSymbolAtLocation(propertyAccess);
+
+                if (symbol && symbol.declarations) {
+                    // If the symbol has multiple declarations, return the constant value
+                    // of the first one that can be computed, if any
+                    for (const declaration of symbol.declarations) {
+                        if (
+                            ts.isPropertyAccessExpression(declaration) || 
+                            ts.isEnumMember(declaration) || 
+                            ts.isElementAccessExpression(declaration)
+                        ) {
+                            const constantValue = typeChecker.getConstantValue(declaration);
+                            if (constantValue) {
+                                return constantValue;
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         return undefined;

--- a/static/types/TWBaseTypes.d.ts
+++ b/static/types/TWBaseTypes.d.ts
@@ -678,6 +678,7 @@ declare function ThingTemplateWithShapes<
 
 type ThingTemplateInstance<T extends keyof ThingTemplates> = ThingTemplates[T]["__thingTemplateType"];
 type ThingShapeInstance<T extends keyof ThingShapes> = ThingShapes[T]["__thingShapeType"];
+type DataShapeInstance<T extends keyof DataShapes> = DataShapes[T]["__dataShapeType"];
 
 /**
  * A variant of the `ThingTemplateWithShapes` mixin that uses key names, making it possible to use templates
@@ -728,6 +729,115 @@ declare function ThingTemplateWithShapesReference<
         (T13 extends keyof ThingShapes ? ThingShapeInstance<T13> : T13)
     );
 
+/**
+ * DataShape base class that enables inheritance.
+ */
+declare function DataShapeBase<
+    T1 extends Constructor<DataShapeBase>, 
+    T2 extends Constructor<DataShapeBase> | {} = {},
+    T3 extends Constructor<DataShapeBase> | {} = {},
+    T4 extends Constructor<DataShapeBase> | {} = {},
+    T5 extends Constructor<DataShapeBase> | {} = {},
+    T6 extends Constructor<DataShapeBase> | {} = {},
+    T7 extends Constructor<DataShapeBase> | {} = {},
+    T8 extends Constructor<DataShapeBase> | {} = {},
+    T9 extends Constructor<DataShapeBase> | {} = {},
+    T10 extends Constructor<DataShapeBase> | {} = {},
+    T11 extends Constructor<DataShapeBase> | {} = {},
+    T12 extends Constructor<DataShapeBase> | {} = {},
+    T13 extends Constructor<DataShapeBase> | {} = {},
+    > (
+        mix1: T1,
+        mix2: T2,
+        mix3?: T3,
+        mix4?: T4,
+        mix5?: T5,
+        mix6?: T6,
+        mix7?: T7,
+        mix8?: T8,
+        mix9?: T9,
+        mix10?: T10,
+        mix11?: T11,
+        mix12?: T12,
+        mix13?: T13,
+    ): 
+    (T1 extends Constructor<DataShapeBase> ? Statics<T1> : {}) & 
+    (T2 extends Constructor<DataShapeBase> ? Statics<T2> : {}) &
+    (T3 extends Constructor<DataShapeBase> ? Statics<T3> : {}) &
+    (T4 extends Constructor<DataShapeBase> ? Statics<T4> : {}) &
+    (T5 extends Constructor<DataShapeBase> ? Statics<T5> : {}) &
+    (T6 extends Constructor<DataShapeBase> ? Statics<T6> : {}) &
+    (T7 extends Constructor<DataShapeBase> ? Statics<T7> : {}) &
+    (T8 extends Constructor<DataShapeBase> ? Statics<T8> : {}) &
+    (T9 extends Constructor<DataShapeBase> ? Statics<T9> : {}) &
+    (T10 extends Constructor<DataShapeBase> ? Statics<T10> : {}) &
+    (T11 extends Constructor<DataShapeBase> ? Statics<T11> : {}) &
+    (T12 extends Constructor<DataShapeBase> ? Statics<T12> : {}) &
+    (T13 extends Constructor<DataShapeBase> ? Statics<T13> : {}) &
+    (new (...args: T1 extends Constructor<DataShapeBase> ? ConstructorParameters<T1> : never[]) => (
+        (T1 extends Constructor<DataShapeBase> ? InstanceType<T1> : T1) &
+        (T2 extends Constructor<DataShapeBase> ? InstanceType<T2> : T2) &
+        (T3 extends Constructor<DataShapeBase> ? InstanceType<T3> : T3) &
+        (T4 extends Constructor<DataShapeBase> ? InstanceType<T4> : T4) &
+        (T5 extends Constructor<DataShapeBase> ? InstanceType<T5> : T5) &
+        (T6 extends Constructor<DataShapeBase> ? InstanceType<T6> : T6) &
+        (T7 extends Constructor<DataShapeBase> ? InstanceType<T7> : T7) &
+        (T8 extends Constructor<DataShapeBase> ? InstanceType<T8> : T8) &
+        (T9 extends Constructor<DataShapeBase> ? InstanceType<T9> : T9) &
+        (T10 extends Constructor<DataShapeBase> ? InstanceType<T10> : T10) &
+        (T11 extends Constructor<DataShapeBase> ? InstanceType<T11> : T11) &
+        (T12 extends Constructor<DataShapeBase> ? InstanceType<T12> : T12) &
+        (T13 extends Constructor<DataShapeBase> ? InstanceType<T13> : T13)
+    ));
+
+/**
+ * Variant of DataShapeBase that allows referencing dataShapes by their name instead of their identifier
+ * Note that only dataShapes declared in this project can be referenced.
+ */
+declare function DataShapeBaseReference<
+    T1 extends keyof DataShapes, 
+    T2 extends keyof DataShapes | {} = {},
+    T3 extends keyof DataShapes | {} = {},
+    T4 extends keyof DataShapes | {} = {},
+    T5 extends keyof DataShapes | {} = {},
+    T6 extends keyof DataShapes | {} = {},
+    T7 extends keyof DataShapes | {} = {},
+    T8 extends keyof DataShapes | {} = {},
+    T9 extends keyof DataShapes | {} = {},
+    T10 extends keyof DataShapes | {} = {},
+    T11 extends keyof DataShapes | {} = {},
+    T12 extends keyof DataShapes | {} = {},
+    T13 extends keyof DataShapes | {} = {},
+    > (
+        mix1: T1,
+        mix2: T2,
+        mix3?: T3,
+        mix4?: T4,
+        mix5?: T5,
+        mix6?: T6,
+        mix7?: T7,
+        mix8?: T8,
+        mix9?: T9,
+        mix10?: T10,
+        mix11?: T11,
+        mix12?: T12,
+        mix13?: T13,
+    ): 
+    (new (...args: any[]) =>
+        (DataShapeInstance<T1>) &
+        (T2 extends keyof DataShapes ? DataShapeInstance<T2> : T2) &
+        (T3 extends keyof DataShapes ? DataShapeInstance<T3> : T3) &
+        (T4 extends keyof DataShapes ? DataShapeInstance<T4> : T4) &
+        (T5 extends keyof DataShapes ? DataShapeInstance<T5> : T5) &
+        (T6 extends keyof DataShapes ? DataShapeInstance<T6> : T6) &
+        (T7 extends keyof DataShapes ? DataShapeInstance<T7> : T7) &
+        (T8 extends keyof DataShapes ? DataShapeInstance<T8> : T8) &
+        (T9 extends keyof DataShapes ? DataShapeInstance<T9> : T9) &
+        (T10 extends keyof DataShapes ? DataShapeInstance<T10> : T10) &
+        (T11 extends keyof DataShapes ? DataShapeInstance<T11> : T11) &
+        (T12 extends keyof DataShapes ? DataShapeInstance<T12> : T12) &
+        (T13 extends keyof DataShapes ? DataShapeInstance<T13> : T13)
+    );
 // #endregion
 
 // #region Creation assertions

--- a/static/types/TWBaseTypes.d.ts
+++ b/static/types/TWBaseTypes.d.ts
@@ -748,7 +748,7 @@ declare function DataShapeBase<
     T13 extends Constructor<DataShapeBase> | {} = {},
     > (
         mix1: T1,
-        mix2: T2,
+        mix2?: T2,
         mix3?: T3,
         mix4?: T4,
         mix5?: T5,
@@ -810,7 +810,7 @@ declare function DataShapeBaseReference<
     T13 extends keyof DataShapes | {} = {},
     > (
         mix1: T1,
-        mix2: T2,
+        mix2?: T2,
         mix3?: T3,
         mix4?: T4,
         mix5?: T5,


### PR DESCRIPTION
Adds support for data shape inheritance. [stefan-lacatus](https://github.com/stefan-lacatus))

Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.

The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))

Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.

Resolves an issue where having global functions enabled would also cause the transformer to inline functions declared in global code.