### PR TITLE
Improve error messages for handling service params

### DIFF
--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -2614,13 +2614,21 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 const typeNode = type.type as ts.TypeReferenceNode;
                 
                 if (!typeNode) {
-                    this.throwErrorForNode(node, `No base type specified for parameter ${parameter.name}.`);
+                    this.throwErrorForNode(node, `No base type specified for parameter '${parameter.name}'.`);
                 }
 
                 parameter.aspects.isRequired = !type.questionToken;
-                const baseType = TypeScriptPrimitiveTypes.includes(typeNode.kind) ? typeNode.getText() : typeNode.typeName.getText();
+                let baseType;
+                if (TypeScriptPrimitiveTypes.includes(typeNode.kind)) {
+                    baseType = typeNode.getText();
+                } else {
+                    if (!typeNode.typeName) {
+                        this.throwErrorForNode(node, `Cannot obtain base type for service paramter '${parameter.name}'.`);
+                    }
+                    baseType = typeNode.typeName.getText();
+                }
                 if (!(baseType in TWBaseTypes)) {
-                    this.throwErrorForNode(node, `Unknown base type ${baseType} specified for parameter ${parameter.name}.`);
+                    this.throwErrorForNode(node, `Unknown base type '${baseType}' specified for parameter '${parameter.name}'.`);
                 }
                 parameter.baseType = TWBaseTypes[baseType];
 


### PR DESCRIPTION
When encountering a misdeclared service like 
```typescript
serviceName({test}: {test: 'foo'})
```
transformer would return a parsing error that doesn't properly point you in the right direction (cannot read property of undefined).
This change improves the error message by properly verifying the type names and throwing a more descriptive error message.