### PR TITLE
V 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+# 1.4.5
+
 Improved the error messages that appear when declaring a service parameter with certain unsupported types. [stefan-lacatus](https://github.com/stefan-lacatus))
+
+Adds support for the `@category` decorator to specify the category of properties, events and services. [stefan-lacatus](https://github.com/stefan-lacatus))
 
 When the type of an expression in an inline SQL statement can't be directly determined, the transformer will now use the primitive type that the expression can be assigned to, if an appropriate one exists, to reduce the need of using type assertions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Improved the error messages that appear when declaring a service parameter with certain unsupported types. [stefan-lacatus](https://github.com/stefan-lacatus))
+
 # 1.4.0
 
 Adds support for data shape inheritance. [stefan-lacatus](https://github.com/stefan-lacatus))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 1.4.5
 
-Improved the error messages that appear when declaring a service parameter with certain unsupported types. [stefan-lacatus](https://github.com/stefan-lacatus))
+Improved the error messages that appear when declaring a service parameter with certain unsupported types. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
-Adds support for the `@category` decorator to specify the category of properties, events and services. [stefan-lacatus](https://github.com/stefan-lacatus))
+Adds support for the `@category` decorator to specify the category of properties, events and services. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 When the type of an expression in an inline SQL statement can't be directly determined, the transformer will now use the primitive type that the expression can be assigned to, if an appropriate one exists, to reduce the need of using type assertions.
 
@@ -10,11 +10,11 @@ Resolves an issue where the type inferrence for the inline SQL parameters when b
 
 # 1.4.0
 
-Adds support for data shape inheritance. [stefan-lacatus](https://github.com/stefan-lacatus))
+Adds support for data shape inheritance. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
 
-The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))
+The transformer will no longer emit members with the `declare` modifier.  ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Adds support for data shape inheritance. [stefan-lacatus](https://github.com/ste
 
 Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
 
+The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))
+
 # 1.3.1
 
 Resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
- - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation, data shape inheritance, `declare` modifier on members
 
 #  License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ const emitResult = program.emit(undefined, () => {}, undefined, undefined, {
         TWThingTransformerFactory(program, path, true, false, twConfig)
     ]
 });
+
+// Fire post transform actions, which enable features like data shape inheritance
+for (const key in twConfig.store) {
+    // Exclude non-transformer entries
+    if (key.startsWith('@')) continue;
+
+    twConfig.store[key].firePostTransformActions();
+}
 ```
 
 After the emit finishes, the transformers will properties to the `store` object of your twconfig object. This is an object whose keys are the names of the generated entities and their values are each an instance of the transformer. Beyond those related to the actual transformation, the transformer has the following public methods that can be invoked after the program's emit method returns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.4.0",
+    "version": "1.4.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-transformer",
-            "version": "1.4.0",
+            "version": "1.4.5",
             "license": "MIT",
             "dependencies": {
                 "typescript": "4.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-transformer",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "typescript": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.4.0",
+    "version": "1.4.5",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -701,7 +701,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 // If this is an environment variable, inline it
                 return process.env[value];
             }
-        } else {
+        }
+        else {
             // Otherwise it may just be a const enum
             return this.program.getTypeChecker().getConstantValue(expression as ts.PropertyAccessExpression);
         }
@@ -1879,7 +1880,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
 
                 this.userGroups[group.name] = group;
             }
-        } else {
+        }
+        else {
             // Properties without an initializer default to being treated as users with no extensions
             const user = principal as TWUser;
             user.extensions = {};
@@ -2282,7 +2284,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
             }
             const typeNode = node.type as ts.TypeReferenceNode;
             return TypeScriptPrimitiveTypes.includes(typeNode.kind) ? typeNode.getText() : typeNode.typeName.getText();
-        } else {
+        }
+        else {
             // If a type has not been specified, try to infer it from the context
             const typeChecker = this.program.getTypeChecker();
             const inferredType = typeChecker.getTypeAtLocation(node);
@@ -2537,7 +2540,8 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 else {
                     this.throwErrorForNode(node, 'The type of the service parameter list cannot be resolved.');
                 }
-            } else {
+            }
+            else {
                type = argList.type as ts.TypeLiteralNode;
             }
 
@@ -4488,17 +4492,19 @@ finally {
             const transformer = this.store[shape] as TWThingTransformer;
             if (transformer) {
                 transformer.fields.forEach(f => {
-                    // If the property is already declared on the child, than that definition overrides the one on the parent
+                    // If the property is already declared on the child, then that definition overrides the one on the parent
                     if (!fieldNames[f.name]) {
                         fieldNames[f.name] = f;
-                    } else {
+                    }
+                    else {
                         messages.push({
                             message: `DataShape "${this.className}" contains field "${f.name}" that is also declared on the parent "${shape}". Declaration on the ${this.exportedName} is going to be used.`,
                             kind: DiagnosticMessageKind.Warning
                         });
                     }
                 })
-            } else {
+            }
+            else {
                 messages.push({
                     message: `DataShapes can only extend other dataShapes declared in the project, and not external ones. DataShape "${this.className}" extends "${shape}".`,
                     kind: DiagnosticMessageKind.Error


### PR DESCRIPTION
Improved the error messages that appear when declaring a service parameter with certain unsupported types. [stefan-lacatus](https://github.com/stefan-lacatus))

Adds support for the `@category` decorator to specify the category of properties, events and services. [stefan-lacatus](https://github.com/stefan-lacatus))

When the type of an expression in an inline SQL statement can't be directly determined, the transformer will now use the primitive type that the expression can be assigned to, if an appropriate one exists, to reduce the need of using type assertions.

Resolves an issue where the type inferrence for the inline SQL parameters when building with the `--debug` argument, while working for non-debug builds.