### PR TITLE
Fix recursive global functions on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.6
+
+Resolves an issue where using recursive global functions would lead to a compilation error when building on windows systems. ([elena-bi](https://github.com/elena-bi))
+
 # 1.4.5
 
 Improved the error messages that appear when declaring a service parameter with certain unsupported types. ([stefan-lacatus](https://github.com/stefan-lacatus))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 1.4.5
 
-Improved the error messages that appear when declaring a service parameter with certain unsupported types. [stefan-lacatus](https://github.com/stefan-lacatus))
+Improved the error messages that appear when declaring a service parameter with certain unsupported types. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
-Adds support for the `@category` decorator to specify the category of properties, events and services. [stefan-lacatus](https://github.com/stefan-lacatus))
+Adds support for the `@category` decorator to specify the category of properties, events and services. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 When the type of an expression in an inline SQL statement can't be directly determined, the transformer will now use the primitive type that the expression can be assigned to, if an appropriate one exists, to reduce the need of using type assertions.
 
@@ -10,11 +10,11 @@ Resolves an issue where the type inferrence for the inline SQL parameters when b
 
 # 1.4.0
 
-Adds support for data shape inheritance. [stefan-lacatus](https://github.com/stefan-lacatus))
+Adds support for data shape inheritance. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 Resolves an issue where using the transformer with `ts.transform` would throw an error when attempting to resolve constant expressions.
 
-The transformer will no longer emit members with the `declare` modifier.  [stefan-lacatus](https://github.com/stefan-lacatus))
+The transformer will no longer emit members with the `declare` modifier.  ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 Resolves an issue where the `__values` helper was in some cases not inlined, preventing the use of transpiled es6 features.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
- - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation, data shape inheritance, `declare` modifier on members
+ - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation, data shape inheritance, `declare` modifier on members.
+ - [elena-bi](https://github.com/elena-bi): bug fixes
 
 #  License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -3592,7 +3592,7 @@ Failed parsing at: \n${node.getText()}\n\n`);
                         // If this function is defined in a different file and hasn't yet been processed, do it now
                         // This is required because otherwise, in the after phase, there will be no reference to this
                         // function that can be inlined
-                        if (filename != this.filename) {
+                        if (this.filename && filename != path.normalize(this.filename)) {
                             if (!this.store['@globalFunctions']?.[name]) {
                                 this.compileGlobalFunction(functionDeclaration);
                             }


### PR DESCRIPTION
Resolves an issue where using recursive global functions would lead to a compilation error when building on windows systems. ([elena-bi](https://github.com/elena-bi))