### PR TITLE
fix: Resolve incorrect filter type being used

### DIFF
--- a/static/types/TWBaseTypes.d.ts
+++ b/static/types/TWBaseTypes.d.ts
@@ -379,7 +379,7 @@ declare interface AndOrQueryFilter<T> {
 }
 
 type SingleValueFilter<T> = keyof T extends infer K ? K extends keyof T ? {
-    type: 'EQ' | 'NE' | 'LIKE' | 'GT' | 'LT' | 'LE' | 'GE', 'NOTLIKE'
+    type: 'EQ' | 'NE' | 'LIKE' | 'GT' | 'LT' | 'LE' | 'GE' | 'NOTLIKE';
     fieldName: K;
     value: T[K];
 } : never : never;

--- a/static/types/TWBaseTypes.d.ts
+++ b/static/types/TWBaseTypes.d.ts
@@ -379,7 +379,7 @@ declare interface AndOrQueryFilter<T> {
 }
 
 type SingleValueFilter<T> = keyof T extends infer K ? K extends keyof T ? {
-    type: 'EQ' | 'NEQ' | 'LIKE' | 'GT' | 'LT' | 'LE' | 'GE'
+    type: 'EQ' | 'NE' | 'LIKE' | 'GT' | 'LT' | 'LE' | 'GE', 'NOTLIKE'
     fieldName: K;
     value: T[K];
 } : never : never;


### PR DESCRIPTION
Resolve the _not equal_ filter being called `NEQ` instead of `NE` and the missing `NOTLIKE`