### PR TITLE
fix: Invalid LOG_PREFIX generated

### DIFF
--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -4291,21 +4291,23 @@ Failed parsing at: \n${node.getText()}\n\n`);
                 }
             }
 
-            result = '\n' + result;
+            let methodHelpers = '';
             if (this.methodHelpers.methodName && method['@methodHelpers'].has('METHOD_NAME')) {
-                result = `const METHOD_NAME = "${name}";\n` + result;
+                methodHelpers += `const METHOD_NAME = "${name}";\n`;
             }
             if (this.methodHelpers.className && method['@methodHelpers'].has('CLASS_NAME')) {
-                result = `const CLASS_NAME = "${entity.className}";\n` + result;
+                methodHelpers += `const CLASS_NAME = "${entity.className}";\n`;
             }
             if (this.methodHelpers.filePath && method['@methodHelpers'].has('FILE_PATH')) {
                 // Relativize the path to the file, to contain it to the project directory
                 const relativeFilePath = entity.projectName + '' + entity.filename?.replace(entity.root, '');
-                result = `const FILE_PATH = "${relativeFilePath}";\n` + result;
+                methodHelpers += `const FILE_PATH = "${relativeFilePath}";\n`;
             }
             if (this.methodHelpers.logPrefix && method['@methodHelpers'].has('LOG_PREFIX')) {
-                result = "const LOG_PREFIX = " + this.methodHelpers.logPrefix  + ";\n" + result;
+                // Because the LOG_PREFIX may reference the other helpers, append it at the end
+                methodHelpers += "const LOG_PREFIX = " + this.methodHelpers.logPrefix + ";\n";
             }
+            result = methodHelpers + result;
         }
         return result;
     }


### PR DESCRIPTION
Previously, if the the LOG_PREFIX statement would be added as the first thing in a file, leading it to be invalid (it references another const before it was declared)
```typescript
const LOG_PREFIX = me.name + '::' + METHOD_NAME + ':: ';
const METHOD_NAME = "HandleDataPointMessage";
```

This change ensures that the `LOG_PREFIX` helper is always added at the end.

```typescript
const METHOD_NAME = "HandleDataPointMessage";
const LOG_PREFIX = me.name + '::' + METHOD_NAME + ':: ';
```