### PR TITLE
1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ It is now possible to specify two optional callbacks via the configuration objec
 
 The configuration object now includes an additional `copyEntities` property. It is not directly used by the transformer, but is used by the cli tools to make it possible to include arbitrary XML entities to be included the built extension.
 
+Resolves an issue where specifying the default value of a service argument would sometimes cause incorrect code to be emitted.
+
 # 1.4.8
 
-Resolves an issue where the `LOG_PREFIX` constant was delcared before the other log helpers which prevented it from referencing them. ([stefan-lacatus](https://github.com/stefan-lacatus))
+Resolves an issue where the `LOG_PREFIX` constant was declared before the other log helpers which prevented it from referencing them. ([stefan-lacatus](https://github.com/stefan-lacatus))
 
 # 1.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 1.5
+
+Added a type guard to the `ImplementsShape` and `IsDerivedFromTemplate` to improve type inferrence when using these to test.
+
+For example, the compiler will now correctly infer that the thing is a `Connectable` in the example below.
+
+```ts
+const thing = Things[name];
+
+if (thing.ImplementsShape({thingShapeName: 'Connectable'})) {
+    logger.debug(`${name} connection status: ${thing.isConnected}`); // <- Not a type error
+}
+```
+
+Added support for generating trace builds that can be used with the `BMProfiler` extension.
+
+It is now possible to specify two optional callbacks via the configuration object:
+ - `transformerWillStartFile(name: string): void` is invoked before the transformer starts processing a file in the "before" phase.
+ - `transformerDidFinishFile(name: string): void` is invoked after the transformer finishes processing a file in the "after" phaase.
+
+The configuration object now includes an additional `copyEntities` property. It is not directly used by the transformer, but is used by the cli tools to make it possible to include arbitrary XML entities to be included the built extension.
+
 # 1.4.8
 
 Resolves an issue where the `LOG_PREFIX` constant was delcared before the other log helpers which prevented it from referencing them. ([stefan-lacatus](https://github.com/stefan-lacatus))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.4.8",
+    "version": "1.5.0",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/schemas/twconfig.schema.json
+++ b/schemas/twconfig.schema.json
@@ -85,6 +85,11 @@
             "description": "Contains option for how inline SQL statements are handled.",
             "markdownDescription": "Contains option for how inline SQL statements are handled."
         },
+        "copyEntities": {
+            "type": "boolean",
+            "description": "When enabled, any XML files in the project's src directory will be copied to the build output directory.",
+            "markdownDescription": "When enabled, any XML files in the project's src directory will be copied to the build output directory."
+        },
         "minimumThingWorxVersion": {
             "type": "string",
             "description": "The minimum thingworx version on which the project may be installed.",

--- a/src/configuration/TWConfig.ts
+++ b/src/configuration/TWConfig.ts
@@ -143,6 +143,30 @@ export interface TWConfig {
     debug?: boolean;
 
     /**
+     * A flag that, when enabled, will cause a trace build to be generated.
+     */
+    trace?: boolean;
+
+    /**
+     * When enabled, any xml files in the source folder will be copied to the build output.
+     */
+    copyEntities?: boolean;
+
+    /**
+     * An optional callback that is invoked before the transformer begins processing
+     * a file.
+     * @param name The name of the file that will be processed.
+     */
+    transformerWillStartFile?(name: string): void;
+
+    /**
+     * An optional callback that is invoked after the transformer has finished processing
+     * a file.
+     * @param name The name of the file that has been processed.
+     */
+    transformerDidFinishFile?(name: string): void;
+
+    /**
      * An object holding transformer instances and global metadata.
      */
     store: {

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -1,5 +1,6 @@
 import type { Node, SourceFile } from 'typescript';
 import type { EmitHelper } from 'typescript';
+import ts = require('typescript');
 
 export interface TWInfoTable {
     dataShape: {
@@ -581,4 +582,64 @@ export interface DiagnosticMessage {
      * If file is specified, the column number for which this diagnostic message was generated.
      */
     column?: number;
+}
+
+/**
+ * An enum that contains the kinds of events that are traced, which is used
+ * to quickly identify the source of the event.
+ */
+export enum TraceKind {
+
+    /**
+     * Indicates that the event source could not be found.
+     */
+    Unknown = 'unknown',
+
+    /**
+     * Indicates that the event source is the standard javascript library.
+     */
+    Standard = 'standard',
+
+    /**
+     * Indicates that the event source is a standard thingworx entity.
+     */
+    Thingworx = 'thingworx',
+
+    /**
+     * Indicates that the event source is an imported project entity.
+     */
+    Import = 'import',
+
+    /**
+     * Indicates that the event source is an entity in the project.
+     */
+    Project = 'project',
+}
+
+/**
+ * An interface that describes an object that contains information
+ * about a trace measurement comma expression.
+ */
+export interface TraceNodeInformation {
+
+    /**
+     * The call expression that is measured.
+     */
+    callExpression: ts.CallExpression;
+
+    /**
+     * The call expression that starts the measurement.
+     */
+    traceStartNode: ts.CallExpression;
+
+    /**
+     * The call expression that finishes the measurement.
+     */
+    traceEndNode: ts.CallExpression;
+
+    /**
+     * A flag that is used to determine whether this measurement should delay the parent measurement's
+     * start timestamp.
+     */
+    delaysParentMeasurement: boolean;
 }

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -633,9 +633,19 @@ export interface TraceNodeInformation {
     traceStartNode: ts.CallExpression;
 
     /**
+     * The assignment expression that assigns the return value.
+     */
+    assignmentNode: ts.AssignmentExpression<ts.EqualsToken>;
+
+    /**
      * The call expression that finishes the measurement.
      */
     traceEndNode: ts.CallExpression;
+
+    /**
+     * The return node.
+     */
+    returnNode: ts.Identifier;
 
     /**
      * A flag that is used to determine whether this measurement should delay the parent measurement's

--- a/static/types/ThingTemplates.d.ts
+++ b/static/types/ThingTemplates.d.ts
@@ -2460,7 +2460,7 @@ declare class MachineTemplate extends GenericThing {
 	 * @param thingShapeName Thing shape name
 	 * @return Implements Shape
 	 */
-	ImplementsShape(args?:{thingShapeName?: THINGSHAPENAME}): BOOLEAN;
+	ImplementsShape<K extends THINGSHAPENAME>(args?:{thingShapeName?: K}): this is ThingShapes[K]['__thingShapeType'];
 
 	/**
 	 * Get the current property values for this thing as VTQ
@@ -2751,7 +2751,7 @@ declare class MachineTemplate extends GenericThing {
 	 * @param thingTemplateName Thing template name
 	 * @return Is Derived From Template
 	 */
-	IsDerivedFromTemplate(args?:{thingTemplateName?: THINGTEMPLATENAME}): BOOLEAN;
+	IsDerivedFromTemplate<K extends THINGTEMPLATENAME>(args?:{thingTemplateName?: K}): this is ThingTemplates[K]['__thingTemplateType'];
 
 	/**
 	 * Store properties of this thing to a stream
@@ -6540,7 +6540,7 @@ declare class GenericThing {
 	 * @param thingShapeName Thing shape name
 	 * @return Implements Shape
 	 */
-	ImplementsShape(args?:{thingShapeName?: THINGSHAPENAME}): BOOLEAN;
+	ImplementsShape<K extends THINGSHAPENAME>(args?:{thingShapeName?: K}): this is ThingShapes[K]['__thingShapeType'];
 
 	/**
 	 * Get the current property values for this thing as VTQ
@@ -6831,7 +6831,7 @@ declare class GenericThing {
 	 * @param thingTemplateName Thing template name
 	 * @return Is Derived From Template
 	 */
-	IsDerivedFromTemplate(args?:{thingTemplateName?: THINGTEMPLATENAME}): BOOLEAN;
+	IsDerivedFromTemplate<K extends THINGTEMPLATENAME>(args?:{thingTemplateName?: K}): this is ThingTemplates[K]['__thingTemplateType'];
 
 	/**
 	 * Store properties of this thing to a stream


### PR DESCRIPTION
Added a type guard to the `ImplementsShape` and `IsDerivedFromTemplate` to improve type inferrence when using these to test.

For example, the compiler will now correctly infer that the thing is a `Connectable` in the example below.

```ts
const thing = Things[name];
if (thing.ImplementsShape({thingShapeName: 'Connectable'})) {
    logger.debug(`${name} connection status: ${thing.isConnected}`); // <- Not a type error
}
```

Added support for generating trace builds that can be used with the `BMProfiler` extension.

It is now possible to specify two optional callbacks via the configuration object:
 - `transformerWillStartFile(name: string): void` is invoked before the transformer starts processing a file in the "before" phase.
 - `transformerDidFinishFile(name: string): void` is invoked after the transformer finishes processing a file in the "after" phaase.

The configuration object now includes an additional `copyEntities` property. It is not directly used by the transformer, but is used by the cli tools to make it possible to include arbitrary XML entities to be included the built extension.

Resolves an issue where specifying the default value of a service argument would sometimes cause incorrect code to be emitted.