### PR TITLE
1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.5.1
+
+For the `allowInstance` and `denyInstance` decorators, an optional resource may now be specified.
+
+Adds support for a new `@indexed` decorator that can be used to mark a property as indexed.
+
+The transformer will no longer throw when the `@deploy` decorator is specified on templates or shapes. Additionally, the `deploymentEndpoints` property is now an array of objects that contains the entity names, service names and entity kinds for the services marked with the decorator.s
+
 # 1.5
 
 Added a type guard to the `ImplementsShape` and `IsDerivedFromTemplate` to improve type inferrence when using these to test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ For the `allowInstance` and `denyInstance` decorators, an optional resource may 
 
 Adds support for a new `@indexed` decorator that can be used to mark a property as indexed.
 
-The transformer will no longer throw when the `@deploy` decorator is specified on templates or shapes. Additionally, the `deploymentEndpoints` property is now an array of objects that contains the entity names, service names and entity kinds for the services marked with the decorator.s
+The transformer will no longer throw when the `@deploy` decorator is specified on templates or shapes. Additionally, the `deploymentEndpoints` property is now an array of objects that contains the entity names, service names and entity kinds for the services marked with the decorator.
 
 # 1.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -50,6 +50,7 @@ export interface TWPropertyDefinition<T = any> extends TWFieldBase<T> {
 export interface TWPropertyAspects<T> extends TWFieldAspects<T> {
     isPersistent?: boolean;
     isLogged?: boolean;
+    isIndexed?: boolean;
     isReadOnly?: boolean;
     isRemote?: boolean;
     dataChangeType: TWPropertyDataChangeKind;
@@ -480,6 +481,28 @@ export interface TWOrganizationalUnit {
     description?: string;
     name: string;
     members: TWMemberBase[];
+}
+
+/**
+ * An interface that describes a service that is marked with the `@deploy` decorator.
+ */
+export interface DeploymentEndpoint {
+
+    /**
+     * The kind of entity.
+     */
+    kind: TWEntityKind;
+
+    /**
+     * The name of the entity.
+     */
+    name: string;
+
+    /**
+     * The name of the service.
+     */
+    service: string;
+
 }
 
 /**

--- a/static/types/Decorators.d.ts
+++ b/static/types/Decorators.d.ts
@@ -386,6 +386,20 @@ declare function denyInstance(...args: (UserEntity | GroupEntity | Permission)[]
 declare function allowInstance(...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
 
 /**
+ * A decorator that can be used to deny specific permissions on an instance of an entity.
+ * @param args      A comma separated list of users, user groups and permissions, in any order.
+ * @param name      The name of the member to which the permission applies.
+ */
+declare function denyInstance(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
+
+/**
+ * A decorator that can be used to allow specific permissions on an instance of an entity.
+ * @param args      A comma separated list of users, user groups and permissions, in any order.
+ * @param name      The name of the member to which the permission applies.
+ */
+declare function allowInstance(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
+
+/**
  * A decorator that can be used to make an entity visible for a set of given organizations.
  * @param args      A comma separated list of organizations.
  */

--- a/static/types/Decorators.d.ts
+++ b/static/types/Decorators.d.ts
@@ -82,6 +82,11 @@ declare function persistent<T extends GenericThing, P>(target: T, key: string, d
 declare function logged<T extends GenericThing, P>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P extends Function ? never : P>): void;
 
 /**
+ * When applied to a property, this makes the property indexed.
+ */
+declare function indexed<T extends GenericThing, P>(target: T, key: string, descriptor?: TypedPropertyDescriptor<P extends Function ? never : P>): void;
+
+/**
  * When applied to a numeric property or data shape field, this sets the property's minimum value aspect.
  * @param minimumValue      The minimum value to set. This must be a numeric literal.
  */


### PR DESCRIPTION
For the `allowInstance` and `denyInstance` decorators, an optional resource may now be specified.

Adds support for a new `@indexed` decorator that can be used to mark a property as indexed.

The transformer will no longer throw when the `@deploy` decorator is specified on templates or shapes. Additionally, the `deploymentEndpoints` property is now an array of objects that contains the entity names, service names and entity kinds for the services marked with the decorator.