### PR TITLE
Conditional compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 1.6
+
+The transformer will now remove if branches when testing against compile time constants with a value of `"false"` or `false`. Additionally it will remove else branches when testing against compile time constants with a value of `"true"` or `true`.
+
+For example, the following branch will be removed if the `FEATURE_ENABLED` environment variable being tested is `"false"`:
+
+```ts
+if (process.env.FEATURE_ENABLED) {
+    this.ProcessData();
+}
+```
+
+The following branch will also be removed:
+```ts
+if ("false") {
+    logger.debug("Received message");
+}
+```
+
+Only simple expressions are currently considered for this feature, so the following branch will not be removed:
+
+```ts
+if (process.env.FEATURE_ENABLED == 'true') {
+    this.ProcessData();
+}
+```
+
+Added a new `@ifenv` decorator that can used to only emit certain entities when an environment variable is defined. For example, the following thing will only be emitted when the value of the `DEVELOPMENT` env variable being tested is `"true"`.
+
+```ts
+@ifenv(process.env.DEVELOPMENT)
+@ThingDefinition class DebugScripts extends GenericThing {
+    ...
+}
+```
+
+When the value of the tested environment variable is `"false"`, neither the entity nor its collection declaration are emitted. This means that compilation will fail if any other entity references it via its collection, even if the accessing entity is also set to not be emitted.
+
 # 1.5.1
 
 For the `allowInstance` and `denyInstance` decorators, an optional resource may now be specified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Thingworx RoIcenter",
     "minimumThingWorxVersion": "6.0.0",

--- a/static/types/Decorators.d.ts
+++ b/static/types/Decorators.d.ts
@@ -9,6 +9,16 @@ declare type Table<T extends DataShapeBase> = undefined;
 declare type MultiRowTable<T extends DataShapeBase> = undefined;
 
 /**
+ * Specifies that the decorated entity should only be emitted if the specified environment variable
+ * exists and doesn't have the value `"false"`.
+ * 
+ * If the specified environment variable is missing or the value is `"false"`, the decorated entity
+ * will not be emitted.
+ * @param variable      The environment variable to test.
+ */
+declare function ifenv(variable: unknown): <T extends new (...args) => any>(target: T) => void;
+
+/**
  * A decorator that can be applied to any entity to create a configuration table for it. This decorator
  * takes a single argument that represents the configuration table definition as a class expression.
  * @param tables        The configuration tables definition.
@@ -36,7 +46,7 @@ declare function valueStream(stream: KeysOfType<Things, ValueStream>): <T extend
 
 /**
  * Specifies that the name of the entity should be different from the name of the class.
- * @param identifier    The identigier to use.
+ * @param identifier    The identifier to use.
  */
 declare function exportName(identifier: string): <T extends new (...args) => any>(target: T) => void;
 


### PR DESCRIPTION
The transformer will now remove if branches when testing against compile time constants with a value of `"false"` or `false`. Additionally it will remove else branches when testing against compile time constants with a value of `"true"` or `true`.

For example, the following branch will be removed if the `FEATURE_ENABLED` environment variable being tested is `"false"`:

```ts
if (process.env.FEATURE_ENABLED) {
    this.ProcessData();
}
```

The following branch will also be removed:
```ts
if ("false") {
    logger.debug("Received message");
}
```

Only simple expressions are currently considered for this feature, so the following branch will not be removed:

```ts
if (process.env.FEATURE_ENABLED == 'true') {
    this.ProcessData();
}
```

Added a new `@ifenv` decorator that can used to only emit certain entities when an environment variable is defined. For example, the following thing will only be emitted when the value of the `DEVELOPMENT` env variable being tested is `"true"`.

```ts
@ifenv(process.env.DEVELOPMENT)
@ThingDefinition class DebugScripts extends GenericThing {
    ...
}
```

When the value of the tested environment variable is `"false"`, neither the entity nor its collection declaration are emitted. This means that compilation will fail if any other entity references it via its collection, even if the accessing entity is also set to not be emitted.