### PR TITLE
Version 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Adds limited support for using the `super` keyword to invoke the base class impl
 
 Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified databse thing.
 
+The transformer will now attempt to infer the return type of services if not specified. Additionally, method overload signatures no longer cause a compilation error. When method overloads are used, only the implementation signature will be used to generate the service definition.
+
 Resolves an issue where the transformer did not generate the proper breakpoint locations for global functions.
 
 Improved the positioning of generated breakpoint locations. These will now be more often placed on the same line in which a statement begins, rather than the position where the previous statement ends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Adds limited support for using the `super` keyword to invoke the base class implementation of a service when overridden by a thing or template. Currently only methods that are known at compile time support this, and only when both the subclass and superclass are part of the project.
 
-Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified databse thing.
+Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified database thing.
 
 The transformer will now attempt to infer the return type of services if not specified. Additionally, method overload signatures no longer cause a compilation error. When method overloads are used, only the implementation signature will be used to generate the service definition.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 1.7
+
+Adds limited support for using the `super` keyword to invoke the base class implementation of a service when overridden by a thing or template. Currently only methods that are known at compile time support this, and only when both the subclass and superclass are part of the project.
+
+Resolves an issue where the transformer did not generate the proper breakpoint locations for global functions.
+
+Improved the positioning of generated breakpoint locations. These will now be more often placed on the same line in which a statement begins, rather than the position where the previous statement ends.
+
+Resolves an issue where constant enum members used in global functions were not inlined.
+
+When referencing environment variables that are not defined when building, the transformer will now replace them with the `undefined` keyword rather than retaining the original source code. Additionally, the transformer will generate a warning diagnostic message whenever such environment variables are encountered.
+
+Added support for breakpoints on caught or uncaught exceptions when creating debug builds.
+
+Debug builds will now generate breakpoint locations prior to throw statements. This will also more accurately allow the debugger to highlight where an exception was thrown.
+
+Updated the `Struct` type to retain modifiers defined on the types it is applied to.
+
+Updated the `ValueCollectionCovertible` type to use `Struct` rather than `Partial`. This will now make it an error to add a row without specifying all required fields.
+
+Added type definitions for enviornment variables. This will allow projects to use them without having to include the node typings, which include a lot of additional symbols that can't actually be used.
+
+Resolves an issue where arrow functions were not properly downleveled to bound functions.
+
+Resolves an issue where shadowing a service parameter caused unexpected behaviour at runtime.
+
 # 1.6.1
 
 Added the type definitions for the `SQLThing` thing template. ([s-amory](https://github.com/s-amory))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.7
 
-Adds limited support for using the `super` keyword to invoke the base class implementation of a service when overridden by a thing or template. Currently only methods that are known at compile time support this, and only when both the subclass and superclass are part of the project.
+Adds limited support for using the `super` keyword to invoke the base class implementation of a service when overridden by a thing or template. Currently only methods that are known at compile time support this, and only when both the subclass and superclass are part of the project. A new `superCalls` key in `twconfig.json` can be used to configure how permissions are handled when invoking superclass implementations.
 
 Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified database thing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Adds limited support for using the `super` keyword to invoke the base class implementation of a service when overridden by a thing or template. Currently only methods that are known at compile time support this, and only when both the subclass and superclass are part of the project.
 
+Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified databse thing.
+
 Resolves an issue where the transformer did not generate the proper breakpoint locations for global functions.
 
 Improved the positioning of generated breakpoint locations. These will now be more often placed on the same line in which a statement begins, rather than the position where the previous statement ends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Adds limited support for using the `super` keyword to invoke the base class impl
 
 Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified database thing.
 
+Resolves an issue where permissions for inline SQL statements were not properly generated if not other permissions were defined on the source entity.
+
 The transformer will now attempt to infer the return type of services if not specified. Additionally, method overload signatures no longer cause a compilation error. When method overloads are used, only the implementation signature will be used to generate the service definition.
 
 Resolves an issue where the transformer did not generate the proper breakpoint locations for global functions.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To build the project, run `npm run build` in the root of the project. This will 
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
  - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation, data shape inheritance, `declare` modifier on members.
  - [elena-bi](https://github.com/elena-bi): bug fixes
- - ([s-amory](https://github.com/s-amory)): `SQLThing` type definition.
+ - [s-amory](https://github.com/s-amory): `SQLThing` type definition.
 
 #  License
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 
 ### Contributors
 
+ - [BogdanMihaiciuc](https://github.com/BogdanMihaiciuc): main developer.
  - [dwil618](https://github.com/dwil618): support for min/max aspects and date initializers.
  - [stefan-lacatus](https://github.com/stefan-lacatus): support for inferred types in property declarations, method helpers, bug fixes, support for the `@exported` decorator and API generation, data shape inheritance, `declare` modifier on members.
  - [elena-bi](https://github.com/elena-bi): bug fixes

--- a/schemas/twconfig.schema.json
+++ b/schemas/twconfig.schema.json
@@ -85,6 +85,19 @@
             "description": "Contains option for how inline SQL statements are handled.",
             "markdownDescription": "Contains option for how inline SQL statements are handled."
         },
+        "superCalls": {
+            "type": "object",
+            "properties": {
+                "permissions": {
+                    "type": "string",
+                    "pattern": "^(none|system|inherit)$",
+                    "description": "Controls how permissions will be set up for the services extracted from superclass calls.",
+                    "markdownDescription": "Controls how permissions will be set up for the services extracted from superclass calls."
+                }
+            },
+            "description": "Contains option for how superclass calls are handled.",
+            "markdownDescription": "Contains option for how superclass calls are handled."
+        },
         "copyEntities": {
             "type": "boolean",
             "description": "When enabled, any XML files in the project's src directory will be copied to the build output directory.",

--- a/src/configuration/TWConfig.ts
+++ b/src/configuration/TWConfig.ts
@@ -48,6 +48,21 @@ export interface InlineSQL {
 }
 
 /**
+ * An interface that describes the `superCalls` property in twconfig.json.
+ */
+export interface SuperCallOptions {
+
+    /**
+     * Controls what permissions are assigned to the services generated from the super calls.
+     * The following values may be used:
+     *  - `"none"`: Default if omitted. The superclass services will not have any permissions assigned to them.
+     *  - `"inherit"`: When used, the superclass services will have the same permissions as the service they are created from.
+     *  - `"system"`: When used, the superclass services will have the `ServiceInvoke` permission allowed for the `System` user.
+     */
+    permissions?: 'none' | 'inherit' | 'system';
+}
+
+/**
  * The interface for the `twconfig.json` file that contains options
  * specific to a thingworx project.
  */
@@ -106,6 +121,11 @@ export interface TWConfig {
      * When enabled, inline SQL queries and commands will be allowed and extracted into services.
      */
     inlineSQL?: InlineSQL;
+
+    /**
+     * Controls how permissions are generated for services created from superclass calls.
+     */
+    superCalls?: SuperCallOptions;
 
     /**
      * The minimum thingworx version on which the project may be installed.

--- a/src/transformer/TWCoreTypes.ts
+++ b/src/transformer/TWCoreTypes.ts
@@ -164,6 +164,12 @@ export interface TWServiceDefinition {
          * The maximum rows.
          */
         maxRows: number;
+
+        /**
+         * If specified, the name of the class on which this service should be installed.
+         * If not specified, the service will be installed on the current class.
+         */
+        targetDatabase?: string;
     }
 }
 

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -6208,19 +6208,22 @@ finally {
             let permissions: TWRuntimePermissionsList = {};
 
             // Move over all generic permissions declared on the class, redefining them
-            // as permissions specific to that service
-            if (this.entityKind == TWEntityKind.Thing) {
-                // Things use runtime permissions
-                if (this.runtimePermissions.runtime?.['*']) {
-                    const permission = {...this.runtimePermissions.runtime['*']};
-                    permissions[service.name] = permission;
+            // as permissions specific to that service, if SQL services are set to copy
+            // the source service's permissions
+            if (this.inlineSQLOptions?.permissions == 'inherit') {
+                if (this.entityKind == TWEntityKind.Thing) {
+                    // Things use runtime permissions
+                    if (this.runtimePermissions.runtime?.['*']) {
+                        const permission = {...this.runtimePermissions.runtime['*']};
+                        permissions[service.name] = permission;
+                    }
                 }
-            }
-            else {
-                // Templates and shapes use runtime instance permissions
-                if (this.runtimePermissions.runtimeInstance?.['*']) {
-                    const permission = {...this.runtimePermissions.runtimeInstance['*']};
-                    permissions[service.name] = permission;
+                else {
+                    // Templates and shapes use runtime instance permissions
+                    if (this.runtimePermissions.runtimeInstance?.['*']) {
+                        const permission = {...this.runtimePermissions.runtimeInstance['*']};
+                        permissions[service.name] = permission;
+                    }
                 }
             }
 

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -4496,7 +4496,7 @@ export class TWThingTransformer implements TWCodeTransformer {
 
                 // Merge the permission into the permissions list, if any was copied
                 if (inheritedPermission[permissionKind]![SQLService.name].ServiceInvoke.length) {
-                    this.mergePermissionListsForNode([this.runtimePermissions, inheritedPermission], node);
+                    this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions, inheritedPermission], node);
                 }
                 break;
             case 'system':
@@ -4514,7 +4514,7 @@ export class TWThingTransformer implements TWCodeTransformer {
                 }
 
                 // Merge the permission into the permissions list
-                this.mergePermissionListsForNode([this.runtimePermissions, systemUserPermission], node);
+                this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions, systemUserPermission], node);
                 break;
         }
 

--- a/static/types/Decorators.d.ts
+++ b/static/types/Decorators.d.ts
@@ -257,6 +257,13 @@ declare function SQLQuery(timeout: number, maxRows: number):
 declare function SQLQuery<T extends Database, D extends DataShapeBase>(target: T, key: string, descriptor: TypedPropertyDescriptor<(...args: any[]) => INFOTABLE<D>>): void;
 
 /**
+ * When applied to a thing, template or shape, this decorator allows writing inline SQL statements in this
+ * entity's services. The inline SQL statements will be converted to services on the specified database or sql thing.
+ * @param database      The name of the database entity on which to place SQL services.
+ */
+declare function database(database: THINGNAME<'Database'> | THINGNAME<'SQLThing'>): <T extends new (...args) => GenericThing>(target: T) => void;
+
+/**
  * When applied to an entity, this causes a configuration table to be emitted for it.
  * @param config        A map of configuration tables.
  */

--- a/static/types/Decorators.d.ts
+++ b/static/types/Decorators.d.ts
@@ -16,20 +16,20 @@ declare type MultiRowTable<T extends DataShapeBase> = undefined;
  * will not be emitted.
  * @param variable      The environment variable to test.
  */
-declare function ifenv(variable: unknown): <T extends new (...args) => any>(target: T) => void;
+declare function ifenv(variable: unknown): <T extends abstract new (...args) => any>(target: T) => void;
 
 /**
  * A decorator that can be applied to any entity to create a configuration table for it. This decorator
  * takes a single argument that represents the configuration table definition as a class expression.
  * @param tables        The configuration tables definition.
  */
-declare function ConfigurationTables(tables: new (...args) => any): <T extends new (...args) => GenericThing>(target: T) => void;
+declare function ConfigurationTables(tables: new (...args) => any): <T extends abstract new (...args) => GenericThing>(target: T) => void;
 
 /**
  * Causes this class to be compiled into a Thing Template. The base class must be a class
  * that extends from `GenericThing` at some point.
  */
-declare function ThingTemplateDefinition<K extends new (...args) => GenericThing>(target: K);
+declare function ThingTemplateDefinition<K extends abstract new (...args) => GenericThing>(target: K);
 
 /**
  * Causes this class to be compiled into a Thing. The base class must be a class
@@ -42,13 +42,13 @@ declare function ThingDefinition<K extends new (...args) => GenericThing>(target
  * This decorator is not valid when applied to Thing Shapes.
  * @param stream        The name of the stream.
  */
-declare function valueStream(stream: KeysOfType<Things, ValueStream>): <T extends new (...args) => GenericThing>(target: T) => void;
+declare function valueStream(stream: KeysOfType<Things, ValueStream>): <T extends abstract new (...args) => GenericThing>(target: T) => void;
 
 /**
  * Specifies that the name of the entity should be different from the name of the class.
  * @param identifier    The identifier to use.
  */
-declare function exportName(identifier: string): <T extends new (...args) => any>(target: T) => void;
+declare function exportName(identifier: string): <T extends abstract new (...args) => any>(target: T) => void;
 
 /**
  * Applies the given identifier to this Thing class.
@@ -66,7 +66,7 @@ declare function published<K extends new (...args) => GenericThing>(target: K);
  * the entity in composer. Note that upgrading this project will cause those modifications
  * to be lost.
  */
-declare function editable<K extends new (...args) => any>(target: K);
+declare function editable<K extends abstract new (...args) => any>(target: K);
 
 /**
  * Within services, this is the name of the current user.
@@ -261,13 +261,13 @@ declare function SQLQuery<T extends Database, D extends DataShapeBase>(target: T
  * entity's services. The inline SQL statements will be converted to services on the specified database or sql thing.
  * @param database      The name of the database entity on which to place SQL services.
  */
-declare function database(database: THINGNAME<'Database'> | THINGNAME<'SQLThing'>): <T extends new (...args) => GenericThing>(target: T) => void;
+declare function database(database: THINGNAME<'Database'> | THINGNAME<'SQLThing'>): <T extends abstract new (...args) => GenericThing>(target: T) => void;
 
 /**
  * When applied to an entity, this causes a configuration table to be emitted for it.
  * @param config        A map of configuration tables.
  */
-declare function config(config: Record<string, any>): (target: new (...args) => any) => void;
+declare function config(config: Record<string, any>): (target: abstract new (...args) => any) => void;
 
 declare interface _remoteServiceArgsLiteral {
     /**
@@ -371,7 +371,7 @@ declare enum Permission {
  * @param name      The name of the member to which the permission applies.
  * @param args      A comma separated list of users, user groups and permissions, in any order.
  */
-declare function deny<T extends new (...args) => unknown>(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): (target: T) => void;
+declare function deny<T extends abstract new (...args) => unknown>(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): (target: T) => void;
 
 /**
  * A decorator that can be used to deny specific permissions on an entity or entity member for a list of users or user groups
@@ -379,7 +379,7 @@ declare function deny<T extends new (...args) => unknown>(name: string, ...args:
  * @param name      The name of the member to which the permission applies.
  * @param args      A comma separated list of users, user groups and permissions, in any order.
  */
-declare function allow<T extends new (...args) => unknown>(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): (target: T) => void;
+declare function allow<T extends abstract new (...args) => unknown>(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): (target: T) => void;
  
 
 /**
@@ -399,39 +399,39 @@ declare function allow(...args: (UserEntity | GroupEntity | Permission)[]): <T e
  * A decorator that can be used to deny specific permissions on an instance of an entity.
  * @param args      A comma separated list of users, user groups and permissions, in any order.
  */
-declare function denyInstance(...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
+declare function denyInstance(...args: (UserEntity | GroupEntity | Permission)[]): <T extends abstract new (...args) => unknown>(target: T) => void;
 
 /**
  * A decorator that can be used to allow specific permissions on an instance of an entity.
  * @param args      A comma separated list of users, user groups and permissions, in any order.
  */
-declare function allowInstance(...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
+declare function allowInstance(...args: (UserEntity | GroupEntity | Permission)[]): <T extends abstract new (...args) => unknown>(target: T) => void;
 
 /**
  * A decorator that can be used to deny specific permissions on an instance of an entity.
  * @param args      A comma separated list of users, user groups and permissions, in any order.
  * @param name      The name of the member to which the permission applies.
  */
-declare function denyInstance(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
+declare function denyInstance(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): <T extends abstract new (...args) => unknown>(target: T) => void;
 
 /**
  * A decorator that can be used to allow specific permissions on an instance of an entity.
  * @param args      A comma separated list of users, user groups and permissions, in any order.
  * @param name      The name of the member to which the permission applies.
  */
-declare function allowInstance(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): <T extends new (...args) => unknown>(target: T) => void;
+declare function allowInstance(name: string, ...args: (UserEntity | GroupEntity | Permission)[]): <T extends abstract new (...args) => unknown>(target: T) => void;
 
 /**
  * A decorator that can be used to make an entity visible for a set of given organizations.
  * @param args      A comma separated list of organizations.
  */
- declare function visible(...args: (OrganizationEntity)[]): <T extends new (...args) => unknown>(target: T) => void;
+ declare function visible(...args: (OrganizationEntity)[]): <T extends abstract new (...args) => unknown>(target: T) => void;
 
 /**
  * A decorator that can be used to make an entity visible for a set of given organizations.
  * @param args      A comma separated list of organizations.
  */
-declare function visibleInstance(...args: (OrganizationEntity)[]): <T extends new (...args) => unknown>(target: T) => void;
+declare function visibleInstance(...args: (OrganizationEntity)[]): <T extends abstract new (...args) => unknown>(target: T) => void;
 
 /**
  * **EXPERIMENTAL**

--- a/static/types/TWBaseTypes.d.ts
+++ b/static/types/TWBaseTypes.d.ts
@@ -100,7 +100,7 @@ declare interface JSONInfoTable<T> {
 
 type INFOTABLE<T = any> = T & InfoTable<T>;
 type InfoTableReference<T extends keyof DataShapes> = DataShapes[T]['__dataShapeType'] & InfoTable<DataShapes[T]['__dataShapeType']>;
-type ValueCollectionConvertible<T> = Partial<T> | ValueCollection<T>;
+type ValueCollectionConvertible<T> = Struct<T> | ValueCollection<T>;
 
 declare class InfoTable<T = any> {
     private constructor();
@@ -433,6 +433,12 @@ type QueryFilter<T> = AndOrQueryFilter<T> |
 
 declare const _event: unique symbol;
 
+declare const process: {
+    env: {
+        [key: string]: string | undefined;
+    }
+}
+
 type NOTHING = void;
 type STRING<T extends string = string> = T;
 type NUMBER<T extends number = number> = T;
@@ -519,7 +525,7 @@ type KeysOfType<Source, Type> = { [K in keyof Source]: Source[K] extends Type ? 
 /**
  * An object type containing all non-method properties of the specified type.
  */
-type Struct<Source> = { [K in NonMethod<Source>] : Source[K] };
+type Struct<Source> = { [K in keyof Source as Source[K] extends Function ? never : K] : Source[K] };
 
 // #endregion
 


### PR DESCRIPTION
Adds limited support for using the `super` keyword to invoke the base class implementation of a service when overridden by a thing or template. Currently only methods that are known at compile time support this, and only when both the subclass and superclass are part of the project.

Adds support for writing inline SQL statements on non-database entities. This requires that the class have a `@database` decorator that specifies a database thing or SQL thing on which the services will actually be installed. The transformer will replace those inline SQL statements with service invokes on the specified database thing.

The transformer will now attempt to infer the return type of services if not specified. Additionally, method overload signatures no longer cause a compilation error. When method overloads are used, only the implementation signature will be used to generate the service definition.

Resolves an issue where the transformer did not generate the proper breakpoint locations for global functions.

Improved the positioning of generated breakpoint locations. These will now be more often placed on the same line in which a statement begins, rather than the position where the previous statement ends.

Resolves an issue where constant enum members used in global functions were not inlined.

When referencing environment variables that are not defined when building, the transformer will now replace them with the `undefined` keyword rather than retaining the original source code. Additionally, the transformer will generate a warning diagnostic message whenever such environment variables are encountered.

Added support for breakpoints on caught or uncaught exceptions when creating debug builds.

Debug builds will now generate breakpoint locations prior to throw statements. This will also more accurately allow the debugger to highlight where an exception was thrown.

Updated the `Struct` type to retain modifiers defined on the types it is applied to.

Updated the `ValueCollectionCovertible` type to use `Struct` rather than `Partial`. This will now make it an error to add a row without specifying all required fields.

Added type definitions for enviornment variables. This will allow projects to use them without having to include the node typings, which include a lot of additional symbols that can't actually be used.

Resolves an issue where arrow functions were not properly downleveled to bound functions.

Resolves an issue where shadowing a service parameter caused unexpected behaviour at runtime. Fixes #58 