### PR TITLE
1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.7.2
+
+Resolves an issue where inline SQL services on non-database entities were not always properly installed on the target database entity.
+
+Adds support for using a line comment `// bm-profiler-disable-next-line` to cause the transformer to not emit any tracing code for the following line.
+
+Resolves an issue where function names and sources were not properly discovered for trace builds.
+
 # 1.7.1
 
 Arrow functions are no longer downleveled to bound functions as this causes an exception to be thrown when callbacks are used with non-native objects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Bogdan Mihaiciuc",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -4920,6 +4920,8 @@ export class TWThingTransformer implements TWCodeTransformer {
             case ts.SyntaxKind.TaggedTemplateExpression:
                 // For tagged template expressions, these are currently always inline SQL
                 return ts.factory.createStringLiteral('<SQL>');
+            case ts.SyntaxKind.CallExpression:
+                return this.traceNameOfNode((expression as ts.CallExpression).expression);
             default:
                 try {
                     // For other kinds, return the entire expression as text
@@ -4987,7 +4989,7 @@ export class TWThingTransformer implements TWCodeTransformer {
     traceExpression(this: TWCodeTransformer, expression: ts.CallExpression, sourceNode?: ts.Node): ts.Expression {
         // Determine where the called expression is coming from, to apply an appropriate color
         // to the measured block at runtime.
-        const symbol = this.program.getTypeChecker().getSymbolAtLocation(sourceNode || expression.expression);
+        const symbol = this.program.getTypeChecker().getSymbolAtLocation(sourceNode?.expression || expression.expression);
         let kind = TraceKind.Unknown;
         const projectPath = path.join(this.repoPath, 'src');
         if (symbol) {

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -6247,6 +6247,7 @@ finally {
 
             // Remove the service from the current class and move it to the target transformer
             this.services.splice(i, 1);
+            i--;
             targetTransformer.services.push(service);
 
             let permissions: TWRuntimePermissionsList = {};


### PR DESCRIPTION
Resolves an issue where inline SQL services on non-database entities were not always properly installed on the target database entity.

Adds support for using a line comment `// bm-profiler-disable-next-line` to cause the transformer to not emit any tracing code for the following line.

Resolves an issue where function names and sources were not properly discovered for trace builds.