### PR TITLE
Update DisableSubscription and EnableSubscription signatures to support Thingworx 9

### DIFF
--- a/static/types/entities/DefaultEntities.d.ts
+++ b/static/types/entities/DefaultEntities.d.ts
@@ -1389,9 +1389,10 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param propertyName Property name
 	 * @param thingName Thing name
 	 * @param eventName Event name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	DisableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING}): NOTHING;
+	DisableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Add or update an event definition
@@ -1955,9 +1956,10 @@ declare class ThingShapeEntity<T extends ThingShapeBase> extends RootEntity {
 	 * @param propertyName Property name
 	 * @param thingName Thing name
 	 * @param eventName Event name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	EnableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING}): NOTHING;
+	EnableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -3187,9 +3189,10 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param propertyName Property name
 	 * @param thingName Thing name
 	 * @param eventName Event name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	DisableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING}): NOTHING;
+	DisableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Add or update an event definition
@@ -3843,9 +3846,10 @@ declare class ThingTemplateEntity<T extends GenericThing> extends RootEntity {
 	 * @param propertyName Property name
 	 * @param thingName Thing name
 	 * @param eventName Event name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	EnableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING}): NOTHING;
+	EnableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified

--- a/static/types/entities/ThingTemplates.d.ts
+++ b/static/types/entities/ThingTemplates.d.ts
@@ -3137,9 +3137,10 @@ declare class MachineTemplate extends GenericThing {
 	 * @param propertyName Property name
 	 * @param eventName Event name
 	 * @param thingName Thing name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	DisableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME}): NOTHING;
+	DisableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Get Training Statistics for given Alert
@@ -3594,9 +3595,10 @@ declare class MachineTemplate extends GenericThing {
 	 * @param propertyName Property name
 	 * @param eventName Event name
 	 * @param thingName Thing name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	EnableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME}): NOTHING;
+	EnableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified
@@ -7217,9 +7219,10 @@ declare class GenericThing {
 	 * @param propertyName Property name
 	 * @param eventName Event name
 	 * @param thingName Thing name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	DisableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME}): NOTHING;
+	DisableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Get Training Statistics for given Alert
@@ -7674,9 +7677,10 @@ declare class GenericThing {
 	 * @param propertyName Property name
 	 * @param eventName Event name
 	 * @param thingName Thing name
+	 * @param subscriptionName Subscription name
 	 * @return result
 	 */
-	EnableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME}): NOTHING;
+	EnableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME} | {subscriptionName?: STRING}): NOTHING;
 
 	/**
 	 * Get the date edit was last modified


### PR DESCRIPTION
`EnableSubscription` was declared as:
`EnableSubscription(args?:{propertyName?: STRING, thingName?: THINGNAME, eventName?: STRING}): NOTHING;`
but since Thingworx 9.0 this method has been deprecated and there is a new one that takes only a subscription name as you can see in their javadoc: https://support.ptc.com/help/thingworx_hc/javadoc/com/thingworx/things/Thing.html#EnableSubscription(java.lang.String)

I think from javascript is not even possible to call the deprecated version anymore (calling it from a java jar should keep working), since trying to call it in a service like: (in this example written from Thingworx UI, not from typescript)
```
me.EnableSubscription({
  thingName: "TestThing",
    eventName: "DataChange",
    prototypeName: "foo"
});
```
leads me to a `Error executing service <service_name>. Message :: A subscription name is required. - See Script Error Log for more details.`
To maintain retrocompatibility I kept both signatures in this PR with a union type like:
`EnableSubscription(args?:{propertyName?: STRING, eventName?: STRING, thingName?: THINGNAME} | {subscriptionName?: STRING}): NOTHING;`

All of the above applies also to `DisableSubscription`