### PR TITLE
Enable support for visible annotations on mashups

### DIFF
--- a/src/transformer/UITransformer.ts
+++ b/src/transformer/UITransformer.ts
@@ -1,7 +1,7 @@
 import * as TS from 'typescript';
 import { ConstantValueUndefined, type TWConfigurationTable, type TWExtractedPermissionLists, type TWInfoTable, type TWThingTransformer, type TWVisibility, type TransformerStore } from './ThingTransformer';
 import { UIControllerReference, UIJSXAttribute, UIMashupBinding, UIMashupEventBinding, UIReference, UIReferenceInitializerFunction, UIReferenceKind, UIServiceReference, UIWidgetReference, UIBaseTypes, UIWidget, UIMashupContent, UIMashupDataItem } from './UICoreTypes';
-import { ArgumentsOfDecoratorNamed, ConfigurationTablesDefinitionWithClassExpression, ConfigurationWithObjectLiteralExpression, ConstantOrLiteralValueOfExpression, DecoratorNamed, HasDecoratorNamed, JSONWithObjectLiteralExpression, ThrowErrorForNode, XMLRepresentationOfInfotable } from './SharedFunctions';
+import { ArgumentsOfDecoratorNamed, ConfigurationTablesDefinitionWithClassExpression, ConfigurationWithObjectLiteralExpression, ConstantOrLiteralValueOfExpression, DecoratorNamed, HasDecoratorNamed, JSONWithObjectLiteralExpression, ThrowErrorForNode, VisibilityPermissionsOfKindForNode, XMLRepresentationOfInfotable } from './SharedFunctions';
 import { Builder } from 'xml2js';
 import { UIBMCollectionViewPlugin, UIBMPresentationControllerPlugin, UINavigationPlugin } from './UIBuiltinPlugins';
 import type { UIPlugin } from './UIPlugin';
@@ -1038,7 +1038,7 @@ export class UITransformer {
 
             //this.runtimePermissions = this.mergePermissionListsForNode([this.runtimePermissions].concat(this.permissionsOfNode(node)), node);
 
-            //this.visibilityPermissions = this.visibilityPermissionsOfKindForNode('visible', node);
+            this.visibilityPermissions = VisibilityPermissionsOfKindForNode('visible', node);
         }
 
         // Defining a mashup class without the renderMashup method is an error


### PR DESCRIPTION
It would be nice to have support to set the visibility permissions on mashups. I tried to implement it myself reusing your existing code and seems to work according to my quick test with a simple mashup. (I haven't tested with a Core UI mashups since I don't know how they work)