### PR TITLE
Fix setup of Printers used in transformers to correcly apply substitutions from previous transformers

### DIFF
--- a/src/transformer/SharedFunctions.ts
+++ b/src/transformer/SharedFunctions.ts
@@ -601,3 +601,12 @@ export function XMLRepresentationOfInfotable(infotable: TWInfoTable, withOrdinal
         ]
     };
 }
+
+export function CreatePrinter(context: TS.TransformationContext): TS.Printer {
+    return TS.createPrinter({},
+        {
+          onEmitNode: context.onEmitNode,
+          isEmitNotificationEnabled: context.isEmitNotificationEnabled,
+          substituteNode: context.onSubstituteNode,
+        });
+}

--- a/src/transformer/ThingTransformer.ts
+++ b/src/transformer/ThingTransformer.ts
@@ -4,7 +4,7 @@ import { TWEntityKind, TWPropertyDefinition, TWServiceDefinition, TWEventDefinit
 import { Breakpoint } from './DebugTypes';
 import { Builder } from 'xml2js';
 import { UITransformer } from './UITransformer';
-import { ConfigurationTablesDefinitionWithClassExpression, ConfigurationWithObjectLiteralExpression, ConstantOrLiteralValueOfExpression, ConstantValueOfExpression, FindOriginalNodeOfExpression, HasDecoratorNamed, JSONWithObjectLiteralExpression, ThrowErrorForNode, XMLRepresentationOfInfotable } from './SharedFunctions';
+import { ConfigurationTablesDefinitionWithClassExpression, ConfigurationWithObjectLiteralExpression, ConstantOrLiteralValueOfExpression, ConstantValueOfExpression, CreatePrinter, FindOriginalNodeOfExpression, HasDecoratorNamed, JSONWithObjectLiteralExpression, ThrowErrorForNode, XMLRepresentationOfInfotable } from './SharedFunctions';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as path from 'path';
@@ -1070,7 +1070,7 @@ export class TWThingTransformer implements TWCodeTransformer {
      * @param node      The source file node.
      */
     compileGlobalCode(node: ts.SourceFile) {
-        const compiledCode = ts.createPrinter().printNode(ts.EmitHint.Unspecified, node, node);
+        const compiledCode = CreatePrinter(this.context).printNode(ts.EmitHint.Unspecified, node, node);
 
         // Note that the exported symbol names are javascript identifiers, so it is safe to use them with dot notation
         this.compiledGlobalCode = compiledCode + '\n\n' + this.globalSymbols.map(symbol => `Object.getPrototypeOf(this).${symbol} = ${symbol};`).join('\n');
@@ -4032,7 +4032,7 @@ export class TWThingTransformer implements TWCodeTransformer {
                                         const declaration = node as ts.FunctionDeclaration;
                                         if (declaration.name?.text == name) {
                                             // Print and save the compiled function
-                                            compiledCode = ts.createPrinter().printNode(ts.EmitHint.Unspecified, node, compiledSourceFile) + '\n';
+                                            compiledCode = CreatePrinter(this.context).printNode(ts.EmitHint.Unspecified, node, compiledSourceFile) + '\n';
                                             transformedNode = node;
                                         }
                                     }
@@ -5528,7 +5528,7 @@ export class TWThingTransformer implements TWCodeTransformer {
             else {
                 // Otherwise create an AST from the function's code, then emit it
                 // Emit the function and add its code to the service
-                const codeToTranspile = ts.createPrinter().printNode(ts.EmitHint.Unspecified, globalFunction.node, globalFunction.sourceFile);
+                const codeToTranspile = CreatePrinter(this.context).printNode(ts.EmitHint.Unspecified, globalFunction.node, globalFunction.sourceFile);
                 const transpileResult = ts.transpileModule(codeToTranspile, {
                     compilerOptions: {
                         ...this.program.getCompilerOptions(),
@@ -5559,7 +5559,7 @@ export class TWThingTransformer implements TWCodeTransformer {
      * @return      The emit result.
      */
     transpiledBodyOfFunctionDeclaration(node: ts.FunctionDeclaration): string {
-        const result = ts.createPrinter().printNode(ts.EmitHint.Unspecified, node.body!, (this as any).source);
+        const result = CreatePrinter(this.context).printNode(ts.EmitHint.Unspecified, node.body!, (this as any).source);
         return result.substring(1, result.length - 1);
     }
 
@@ -5850,7 +5850,7 @@ finally {
 }`
                 }
                 else {
-                    //const body = ts.createPrinter().printNode(ts.EmitHint.Unspecified, node.body, (this as any).source);
+                    //const body = CreatePrinter(this.context).printNode(ts.EmitHint.Unspecified, node.body, (this as any).source);
                     subscription.code = `(function () {${transpiledBody}}).apply(me)`;
                 }
             }

--- a/src/transformer/UITransformer.ts
+++ b/src/transformer/UITransformer.ts
@@ -1,7 +1,7 @@
 import * as TS from 'typescript';
 import { ConstantValueUndefined, type TWConfigurationTable, type TWExtractedPermissionLists, type TWInfoTable, type TWThingTransformer, type TWVisibility, type TransformerStore } from './ThingTransformer';
 import { UIControllerReference, UIJSXAttribute, UIMashupBinding, UIMashupEventBinding, UIReference, UIReferenceInitializerFunction, UIReferenceKind, UIServiceReference, UIWidgetReference, UIBaseTypes, UIWidget, UIMashupContent, UIMashupDataItem } from './UICoreTypes';
-import { ArgumentsOfDecoratorNamed, ConfigurationTablesDefinitionWithClassExpression, ConfigurationWithObjectLiteralExpression, ConstantOrLiteralValueOfExpression, DecoratorNamed, HasDecoratorNamed, JSONWithObjectLiteralExpression, ThrowErrorForNode, XMLRepresentationOfInfotable } from './SharedFunctions';
+import { ArgumentsOfDecoratorNamed, ConfigurationTablesDefinitionWithClassExpression, ConfigurationWithObjectLiteralExpression, ConstantOrLiteralValueOfExpression, CreatePrinter, DecoratorNamed, HasDecoratorNamed, JSONWithObjectLiteralExpression, ThrowErrorForNode, XMLRepresentationOfInfotable } from './SharedFunctions';
 import { Builder } from 'xml2js';
 import { UIBMCollectionViewPlugin, UIBMPresentationControllerPlugin, UINavigationPlugin } from './UIBuiltinPlugins';
 import type { UIPlugin } from './UIPlugin';
@@ -381,7 +381,7 @@ export class UITransformer {
                 if (this.isBMCoreUIMashup && this.controllerWidget) {
                     // There is no processing to be done for UI files in the after phase, but for core ui mashups, the 
                     // compiled code must be saved to the typescript class widget
-                    const compiledCode = TS.createPrinter().printNode(TS.EmitHint.Unspecified, node, node);
+                    const compiledCode = CreatePrinter(this.context).printNode(TS.EmitHint.Unspecified, node, node);
                     this.controllerWidget.Properties.TranspiledCode = compiledCode;
                 }  
             }
@@ -413,7 +413,7 @@ export class UITransformer {
 
             // If this is a Core UI mashup, store the updated code in the controller widget
             if (this.isBMCoreUIMashup && this.controllerWidget) {
-                const updatedCode = TS.createPrinter().printNode(TS.EmitHint.Unspecified, result, result as TS.SourceFile);
+                const updatedCode = CreatePrinter(this.context).printNode(TS.EmitHint.Unspecified, result, result as TS.SourceFile);
                 this.controllerWidget.Properties.Code = updatedCode;
             }
 


### PR DESCRIPTION
All usages of of ts.createPrinter inside both transformer need to configure the PrintHandlers with the settings from the TransformationContext, otherwise the generated javascript code will be different from the code that the typescript compiler would have generated.

This PR solves the issue with the usage of `this` in arrow functions ( https://github.com/ptc-iot-sharing/ThingworxVSCodeProject/issues/65 ), in particular adding the `substituteNode` handler allows the printer to call the `onSubstituteNode` of the es2015 transformer that replaces `this` with `_this`.