### PR TITLE
Fix mashup parameter bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.6
+
+Resolves an issue where bindings to/from mashup parameters did not work at runtime.
+
+Resolves an issue where passing or retrieving mashup parameter values did not work for the `Navigationfunction` widget.
+
 # 2.1.5
 
 Adds support for using the `@visible` decorator to assign visibility permissions to mashups. ([kklorenzotesta](https://github.com/kklorenzotesta))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bm-thing-transformer",
-    "version": "2.1.0",
+    "version": "2.1.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-transformer",
-            "version": "2.1.0",
+            "version": "2.1.6",
             "license": "MIT",
             "dependencies": {
                 "typescript": "5.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Bogdan Mihaiciuc",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/UIBuiltinPlugins.ts
+++ b/src/transformer/UIBuiltinPlugins.ts
@@ -29,13 +29,23 @@ export class UINavigationPlugin implements UIPlugin {
     }
 
     transformerDidProcessWidget(transformer: UITransformer, className: string, element: TS.JsxElement | TS.JsxSelfClosingElement, widget: UIWidget) {
-        // Get the mashup parameters and then 
+        // Get the mashup parameters and then build the array of parameters that the widget uses
+        // to separate out generic properties from parameter proeprties
         const mashupName = widget.Properties[this.sourcePropertyName];
         if (mashupName && typeof mashupName == 'string') {
             const parameters = transformer.parametersOfMashupNamed(mashupName);
             if (parameters) {
                 widget.Properties[this.targetPropertyName] = parameters.map(p => {
-                    return {ParameterName: p.name, Description: '', BaseType: p.baseType};
+                    return {
+                        ParameterName: p.name,
+                        Description: '',
+                        BaseType: p.baseType,
+                        bindingDirection: 'both',
+                        bindingType: 'Property',
+                        isBindingSource: true,
+                        isBindingTarget: true,
+                        shown: true
+                    };
                 });
             }
         }

--- a/src/transformer/UITransformer.ts
+++ b/src/transformer/UITransformer.ts
@@ -55,7 +55,7 @@ export class UITransformer {
      */
     static plugins: Record<string, UIPlugin> = {
         Navigation: new UINavigationPlugin('MashupName', 'MashupParameters'),
-        Navigationfunction: new UINavigationPlugin('TargetMashup', 'MashupParameters'),
+        Navigationfunction: new UINavigationPlugin('TargetMashup', '_currentParameterDefs'),
         Mashupcontainer: new UINavigationPlugin('Name', 'MashupParameters'),
 
         BMCollectionView: new UIBMCollectionViewPlugin,

--- a/src/transformer/UITransformer.ts
+++ b/src/transformer/UITransformer.ts
@@ -651,8 +651,8 @@ export class UITransformer {
 
                 this.visitMashupParametersDeclaration(argument);
 
-                // Store the reference and mark this node for deletion
-                this.references[ID] = {kind: UIReferenceKind.Widget, ID, className: 'Mashup'} as UIWidgetReference;
+                // Store the reference and mark this node for deletion; the ID for the mashup element MUST be mashup-root
+                this.references[ID] = {kind: UIReferenceKind.Widget, ID: 'mashup-root', className: 'Mashup'} as UIWidgetReference;
                 this.nodeReplacementMap.set(node, undefined);
                 return true;
             }
@@ -2238,8 +2238,8 @@ export class UITransformer {
                 let finalFlags = types[0]?.flags || 0;
                 for (const type of types) {
                     // Exclude optional flags
-                    if (type.flags && TS.TypeFlags.Undefined) continue;
-                    if (type.flags && TS.TypeFlags.Null) continue;
+                    if (type.flags & TS.TypeFlags.Undefined) continue;
+                    if (type.flags & TS.TypeFlags.Null) continue;
 
                     finalFlags &= type.flags;
                 }


### PR DESCRIPTION
Resolves an issue where bindings to/from mashup parameters did not work at runtime.

Resolves an issue where passing or retrieving mashup parameter values did not work for the `Navigationfunction` widget.