### PR TITLE
2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.7
+
+Resolves an issue where widget bindings sometimes required explicit type assertions.
+
+Resolves an issue where infotable properties defined in a core ui controller could not be used in widget bindings.
+
 # 2.1.6
 
 Resolves an issue where bindings to/from mashup parameters did not work at runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bm-thing-transformer",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-transformer",
-            "version": "2.1.6",
+            "version": "2.1.7",
             "license": "MIT",
             "dependencies": {
                 "typescript": "5.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-transformer",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "description": "Develop in ThingWorx with a proper IDE.",
     "author": "Bogdan Mihaiciuc",
     "minimumThingWorxVersion": "6.0.0",

--- a/src/transformer/UITransformer.ts
+++ b/src/transformer/UITransformer.ts
@@ -2146,6 +2146,17 @@ export class UITransformer {
             }
         }
 
+        // If this is a union between a type and a binding target to that same type, that type
+        // will represent the thingworx base type
+        if (type.isUnion() && type.types.length == 2) {
+            const firstType = this.baseTypeOfType(type.types[0]);
+            const secondType = this.baseTypeOfType(type.types[1]);
+
+            if (firstType == secondType) {
+                return firstType;
+            }
+        }
+
         // If the type is a binding target type, extract the generic argument and resolve it
         if (type.symbol?.escapedName == 'BindingTarget') {
             if ('typeArguments' in type) {

--- a/ui/types/UIBaseTypes.d.ts
+++ b/ui/types/UIBaseTypes.d.ts
@@ -154,11 +154,18 @@ declare type MashupControllerExtendedKeys<T> = {[K in keyof T]: K extends keyof 
  */
 declare type ToMashupController<T> = {
     // Map all keys to binding targets, except for the base widget properties
-    [K in MashupControllerExtendedKeys<T>]: T[K] extends Function ? ServiceBindingTarget : BindingTarget<T[K]>;
+    [K in MashupControllerExtendedKeys<T>]:
+        T[K] extends Function ? 
+        ServiceBindingTarget : 
+        (
+            T[K] extends JSONInfoTable<infer R> ? 
+            BindingTarget<INFOTABLE<R>> : 
+            BindingTarget<T[K]>
+        );
 }
 
 /**
- * A class that all widget contructor property types should extend to provide support for dynamic properties.
+ * A class that all widget constructor property types should extend to provide support for dynamic properties.
  */
 declare class UIBaseInputInterface {
     [key: `Dynamic:${string}`]: any;


### PR DESCRIPTION
Resolves an issue where widget bindings sometimes required explicit type assertions.

Resolves an issue where infotable properties defined in a core ui controller could not be used in widget bindings.